### PR TITLE
style(frontend): strengthen sidebar active state presence

### DIFF
--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -143,11 +143,13 @@
 .sidebar-item.is-active {
   color: var(--text-accent);
   border-left-color: var(--text-accent);
-  background: color-mix(in srgb, var(--text-accent) 8%, var(--bg-surface));
+  border-left-width: 3px;
+  background: color-mix(in srgb, var(--text-accent) 14%, var(--bg-surface));
+  font-weight: 600;
 }
 
 .sidebar-item.is-active:hover {
-  background: color-mix(in srgb, var(--text-accent) 12%, var(--bg-surface));
+  background: color-mix(in srgb, var(--text-accent) 18%, var(--bg-surface));
 }
 
 /* ── Sidebar icons ────────────────────────────────────── */
@@ -172,6 +174,7 @@
 
 .sidebar-item.is-active .sidebar-icon {
   opacity: 1;
+  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--text-accent) 50%, transparent));
 }
 
 /* ── Sidebar label ────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Increase border-left-width from 2px to 3px for prominent active indicator
- Raise background opacity from 8% to 14% (hover: 12% to 18%) for stronger contrast
- Add font-weight: 600 to active items for clearer text hierarchy
- Add subtle drop-shadow glow to active icons for visual emphasis

## Test plan
- [x] Unit tests pass (660 tests)
- [x] E2E browser test verified no console errors
- [x] Screenshot captured showing active state enhancement

🤖 Generated with [Claude Code](https://claude.com/claude-code)