### PR TITLE
refactor(frontend): refine surface tier system with stricter differentiation

### DIFF
--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1,10 +1,6 @@
 /* ============================================
    SURFACE HIERARCHY
-   ============================================
-
-   Primary: Commanding, high contrast — live data, primary actions
-   Standard: Current treatment, default for most content
-   Quiet: No border, transparent background, for metadata and secondary info
+   See design-system.css for tier usage guidelines.
    ============================================ */
 
 /* ── Base Surface Classes ───────────────────────────────────── */
@@ -13,18 +9,24 @@
   border: var(--surface-primary-border-width) solid var(--surface-primary-border);
   border-left: var(--surface-primary-accent-width) solid var(--surface-primary-border-accent);
   background: var(--surface-primary-bg);
+  box-shadow: var(--surface-primary-shadow);
+  color: var(--surface-primary-text);
   padding: var(--space-5);
 }
 
 .surface-standard {
   border: var(--surface-standard-border-width) solid var(--surface-standard-border);
   background: var(--surface-standard-bg);
+  box-shadow: var(--surface-standard-shadow);
+  color: var(--surface-standard-text);
   padding: var(--space-4);
 }
 
 .surface-quiet {
-  border: 1px solid transparent;
+  border: 1px solid var(--surface-quiet-border);
   background: var(--surface-quiet-bg);
+  box-shadow: var(--surface-quiet-shadow);
+  color: var(--surface-quiet-text);
   padding: var(--space-4);
 }
 
@@ -33,9 +35,11 @@
 .mc-command,
 .mc-live-panel,
 .mc-status-primary {
-  border: var(--stroke-default) solid var(--border-stitch);
+  border: var(--stroke-default) solid var(--surface-primary-border);
   border-left: var(--stroke-emphasis) solid var(--text-accent);
   background: var(--surface-primary-bg);
+  box-shadow: var(--surface-primary-shadow);
+  color: var(--surface-primary-text);
   padding: var(--space-5);
 }
 
@@ -69,7 +73,8 @@
 .mc-empty-state,
 .mc-metadata {
   border: var(--stroke-default) solid transparent;
-  background: transparent;
+  background: var(--surface-quiet-bg);
+  color: var(--surface-quiet-text);
   padding: var(--space-4);
 }
 

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -248,30 +248,75 @@ body {
 
 /* ============================================
    SURFACE HIERARCHY TOKENS
-   Three-tier system: Primary (command), Standard, Quiet (support)
+   Three-tier system: Primary (command), Standard (content), Quiet (support)
+
+   ── TIER USAGE GUIDELINES ─────────────────────────────────────
+
+   PRIMARY SURFACE
+   - Use for: Command panels, live data displays, primary actions
+   - Character: Commanding presence, highest visual weight
+   - Features: Copper accent border (left), subtle elevation shadow,
+               slightly elevated background, stronger border
+   - Examples: Active run panels, command input areas, live status cards
+
+   STANDARD SURFACE
+   - Use for: Default containers, list items, content cards
+   - Character: Balanced, readable, default treatment
+   - Features: Basic 1px border, surface background, no accent
+   - Examples: Issue cards, event rows, stat cards, toolbars
+
+   QUIET SURFACE
+   - Use for: Metadata, secondary info, supporting content
+   - Character: Minimal presence, recedes visually
+   - Features: No border, muted background, lowest contrast
+   - Examples: Metadata labels, secondary text areas, empty states
+
+   ── VISUAL HIERARCHY RULES ────────────────────────────────────
+
+   1. Primary surfaces should draw the eye first
+   2. Standard surfaces provide the main content structure
+   3. Quiet surfaces should never compete for attention
+   4. Never nest same-tier surfaces (e.g., primary within primary)
+
    ============================================ */
 
 :root {
   /* Primary Surface — commanding presence, copper accent */
-  --surface-primary-border: var(--border-default);
+  --surface-primary-border: var(--border-strong);
   --surface-primary-border-accent: var(--text-accent);
   --surface-primary-bg: var(--bg-surface);
   --surface-primary-border-width: 1px;
   --surface-primary-accent-width: 3px;
+  --surface-primary-shadow: var(--shadow-sm);
+  --surface-primary-text: var(--text-primary);
 
   /* Standard Surface — default bordered containers */
   --surface-standard-border: var(--border-default);
   --surface-standard-bg: var(--bg-surface);
   --surface-standard-border-width: 1px;
+  --surface-standard-shadow: none;
+  --surface-standard-text: var(--text-primary);
 
   /* Quiet Surface — subtle, minimal frame */
   --surface-quiet-border: transparent;
-  --surface-quiet-bg: transparent;
+  --surface-quiet-bg: var(--bg-muted);
+  --surface-quiet-shadow: none;
+  --surface-quiet-text: var(--text-secondary);
 }
 
 [data-theme="dark"] {
-  /* Primary Surface — slightly elevated in dark mode */
-  --surface-primary-bg: color-mix(in srgb, var(--bg-elevated) 40%, var(--bg-surface));
+  /* Primary Surface — elevated and accentuated in dark mode */
+  --surface-primary-bg: color-mix(in srgb, var(--bg-elevated) 50%, var(--bg-surface));
+  --surface-primary-border: var(--border-strong);
+  --surface-primary-shadow: 0 2px 8px -2px rgb(0 0 0 / 0.35);
+
+  /* Standard Surface — clean default in dark mode */
+  --surface-standard-bg: var(--bg-surface);
+  --surface-standard-border: var(--border-default);
+
+  /* Quiet Surface — subtle muted background in dark mode */
+  --surface-quiet-bg: var(--bg-muted);
+  --surface-quiet-text: var(--text-muted);
 }
 
 /* ============================================


### PR DESCRIPTION
## Summary

- Refines the 3-tier surface system (Primary/Standard/Quiet) with stricter visual differentiation
- Adds comprehensive tier usage guidelines documenting when to use each tier
- Strengthens visual hierarchy through new design tokens (shadow, text color per tier)

## Changes

### Design Tokens (`design-system.css`)
- **Primary Surface**: Stronger border (`--border-strong`), elevation shadow, slightly elevated background
- **Standard Surface**: Clean default with shadow/text tokens for consistency
- **Quiet Surface**: Muted background (`--bg-muted`), secondary text color for visual recession
- **Dark Mode**: Enhanced primary surface elevation and darker shadows

### Component Classes (`components.css`)
- Updated `.surface-primary`, `.surface-standard`, `.surface-quiet` to use new tokens
- Updated `.mc-command`, `.mc-live-panel`, `.mc-status-primary` with primary tokens
- Updated `.mc-drawer`, `.mc-empty-state`, `.mc-metadata` with quiet tokens
- Centralized documentation in `design-system.css` to avoid duplication

## Visual Hierarchy Rules

1. Primary surfaces draw the eye first (command panels, live data)
2. Standard surfaces provide main content structure (cards, lists)
3. Quiet surfaces never compete for attention (metadata, secondary info)
4. Never nest same-tier surfaces

## Test Plan

- [x] Unit tests pass (660 passed)
- [x] No console errors in browser
- [x] Visual verification via screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)