### PR TITLE
style(frontend): improve header composition and hierarchy

### DIFF
--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -293,8 +293,7 @@
   height: var(--header-height);
   border-bottom: 1px solid var(--border-stitch);
   background: var(--bg-surface);
-  display: grid;
-  grid-template-columns: 1fr minmax(220px, 420px) 1fr;
+  display: flex;
   align-items: center;
   gap: var(--space-4);
   padding: 0 var(--space-5);
@@ -344,10 +343,27 @@
   font-size: var(--text-lg);
   color: var(--text-primary);
   letter-spacing: var(--tracking-snug);
+  gap: var(--space-2);
 }
 
-.header-separator {
-  color: var(--text-muted);
+.header-brand-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  color: var(--text-accent);
+  flex-shrink: 0;
+}
+
+.header-brand-icon svg {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+}
+
+.header-brand-name {
+  color: var(--text-primary);
 }
 
 .header-env-badge {
@@ -355,11 +371,18 @@
   align-items: center;
   gap: var(--space-1);
   padding: 2px var(--space-2);
+  margin-left: var(--space-1);
   font-size: var(--text-xs);
+  font-weight: 500;
   color: var(--text-secondary);
-  background: color-mix(in srgb, var(--status-running) 12%, var(--bg-elevated));
-  border: 1px solid color-mix(in srgb, var(--status-running) 30%, var(--border-stitch));
+  background: color-mix(in srgb, var(--status-running) 10%, var(--bg-elevated));
+  border: 1px solid color-mix(in srgb, var(--status-running) 25%, var(--border-stitch));
   cursor: help;
+  transition: background-color var(--motion-fast) var(--ease-out-quart);
+}
+
+.header-env-badge:hover {
+  background: color-mix(in srgb, var(--status-running) 16%, var(--bg-elevated));
 }
 
 .header-env-badge .status-dot {
@@ -372,12 +395,23 @@
   text-transform: capitalize;
 }
 
+/* Header zone separators */
+.header-zone-separator {
+  width: 1px;
+  height: 24px;
+  background: var(--border-stitch);
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
 .header-command {
   justify-content: center;
+  flex: 1;
 }
 
 .header-actions {
   justify-content: flex-end;
+  gap: var(--space-2);
 }
 
 .header-action-btn.is-disabled {
@@ -387,10 +421,10 @@
 .header-command-trigger {
   display: flex;
   align-items: center;
-  gap: var(--space-2);
+  gap: var(--space-3);
   width: 100%;
-  max-width: 380px;
-  height: 32px;
+  max-width: 420px;
+  height: 34px;
   padding: 0 var(--space-3);
   background: var(--bg-elevated);
   border: 1px solid var(--border-stitch);
@@ -398,11 +432,36 @@
   font-family: var(--font-body);
   font-size: var(--text-ui);
   cursor: pointer;
-  transition: border-color var(--motion-fast) var(--ease-out-quart);
+  transition:
+    border-color var(--motion-fast) var(--ease-out-quart),
+    background-color var(--motion-fast) var(--ease-out-quart);
 }
 
 .header-command-trigger:hover {
   border-color: var(--border-strong);
+  background: var(--bg-surface);
+}
+
+.header-command-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-subtle);
+  flex-shrink: 0;
+}
+
+.header-command-icon svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+
+.header-command-label {
+  flex: 1;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .header-command-hint {
@@ -413,11 +472,12 @@
   font-family: var(--font-mono);
   font-size: var(--text-xxs);
   color: var(--text-muted);
+  flex-shrink: 0;
 }
 
 .header-action-btn {
-  width: 32px;
-  height: 32px;
+  width: 34px;
+  height: 34px;
   display: grid;
   place-items: center;
   background: transparent;
@@ -426,11 +486,13 @@
   cursor: pointer;
   transition:
     color var(--motion-fast) var(--ease-out-quart),
+    background-color var(--motion-fast) var(--ease-out-quart),
     border-color var(--motion-fast) var(--ease-out-quart);
 }
 
 .header-action-btn:hover {
   color: var(--text-accent);
+  background: var(--bg-elevated);
   border-color: var(--border-stitch);
 }
 

--- a/frontend/src/ui/header.ts
+++ b/frontend/src/ui/header.ts
@@ -3,16 +3,23 @@ import { createIcon } from "./icons";
 import { toggleTheme } from "./theme";
 import { toast } from "./toast";
 
+function createZoneSeparator(): HTMLElement {
+  const separator = document.createElement("div");
+  separator.className = "header-zone-separator";
+  return separator;
+}
+
 export function initHeader(headerEl: HTMLElement): void {
   headerEl.replaceChildren();
 
   const brand = document.createElement("div");
   brand.className = "header-brand";
+  const brandIcon = document.createElement("span");
+  brandIcon.className = "header-brand-icon";
+  brandIcon.append(createIcon("planner", { size: 20 }));
   const titleSpan = document.createElement("span");
+  titleSpan.className = "header-brand-name";
   titleSpan.textContent = "Symphony";
-  const sep = document.createElement("span");
-  sep.className = "header-separator";
-  sep.textContent = "·";
   const badgeSpan = document.createElement("span");
   badgeSpan.className = "mc-badge header-env-badge";
   const dot = document.createElement("span");
@@ -24,19 +31,23 @@ export function initHeader(headerEl: HTMLElement): void {
   badgeSpan.append(dot, envLabel);
   badgeSpan.title =
     "Local mode — Symphony is running on your machine. Issues are processed in sandboxed Docker containers for security.";
-  brand.append(titleSpan, sep, badgeSpan);
+  brand.append(brandIcon, titleSpan, badgeSpan);
 
   const command = document.createElement("div");
   command.className = "header-command";
   const commandButton = document.createElement("button");
   commandButton.type = "button";
   commandButton.className = "header-command-trigger";
+  const searchIcon = document.createElement("span");
+  searchIcon.className = "header-command-icon";
+  searchIcon.append(createIcon("overview", { size: 14 }));
   const cmdLabel = document.createElement("span");
+  cmdLabel.className = "header-command-label";
   cmdLabel.textContent = "Search routes, issues, actions\u2026";
   const cmdHint = document.createElement("span");
   cmdHint.className = "header-command-hint";
   cmdHint.textContent = "Ctrl+K";
-  commandButton.append(cmdLabel, cmdHint);
+  commandButton.append(searchIcon, cmdLabel, cmdHint);
   commandButton.addEventListener("click", () => {
     window.dispatchEvent(new CustomEvent("palette:open"));
   });
@@ -78,5 +89,5 @@ export function initHeader(headerEl: HTMLElement): void {
   });
 
   actions.append(refreshButton, themeButton);
-  headerEl.append(brand, command, actions);
+  headerEl.append(brand, createZoneSeparator(), command, createZoneSeparator(), actions);
 }


### PR DESCRIPTION
## Summary

- Add brand icon (planner) with copper accent before Symphony wordmark for better visual presence
- Add search icon to command palette trigger for improved affordance
- Add visual separators between header zones (brand, command, actions) for clearer hierarchy
- Increase command trigger and action button sizes from 32px to 34px for better touch targets
- Refine environment badge styling with subtle hover state
- Extract `createZoneSeparator` helper to eliminate code duplication

## Test plan

- [x] Run `npm test` - all 660 tests pass
- [x] Build frontend with `npm run build`
- [x] Start dev server and verify header renders correctly
- [x] Check browser console for JS errors - none found
- [x] Verify dark mode appearance
- [x] Verify no breaking changes to header functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)