### PR TITLE
test(orchestrator): add issue-locator, view-builders, and lifecycle-events tests

### DIFF
--- a/tests/orchestrator/issue-locator.test.ts
+++ b/tests/orchestrator/issue-locator.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveIssue, toIssueView, type IssueLocatorCallbacks } from "../../src/orchestrator/issue-locator.js";
+import {
+  createIssue,
+  createModelSelection,
+  createRunningEntry,
+  createRetryEntry,
+  createCompletedView,
+  createDetailView,
+} from "./issue-test-factories.js";
+
+function createCallbacks(overrides?: Partial<IssueLocatorCallbacks>): IssueLocatorCallbacks {
+  return {
+    getRunningEntries: () => new Map(),
+    getRetryEntries: () => new Map(),
+    getCompletedViews: () => new Map(),
+    getDetailViews: () => new Map(),
+    resolveModelSelection: () => createModelSelection(),
+    ...overrides,
+  };
+}
+
+describe("issue-locator", () => {
+  describe("resolveIssue", () => {
+    it("returns null when the identifier is not found in any state map", () => {
+      const callbacks = createCallbacks();
+      const result = resolveIssue("MT-99", callbacks);
+      expect(result).toBeNull();
+    });
+
+    it("finds an issue in the running state", () => {
+      const runningEntry = createRunningEntry();
+      const callbacks = createCallbacks({
+        getRunningEntries: () => new Map([["run-1", runningEntry]]),
+      });
+
+      const result = resolveIssue("MT-42", callbacks);
+
+      expect(result).toEqual({ kind: "running", entry: runningEntry });
+    });
+
+    it("finds an issue in the retry state", () => {
+      const retryEntry = createRetryEntry();
+      const callbacks = createCallbacks({
+        getRetryEntries: () => new Map([["MT-43", retryEntry]]),
+      });
+
+      const result = resolveIssue("MT-43", callbacks);
+
+      expect(result).toEqual({ kind: "retry", entry: retryEntry });
+    });
+
+    it("finds an issue in the completed state", () => {
+      const completedView = createCompletedView();
+      const callbacks = createCallbacks({
+        getCompletedViews: () => new Map([["MT-44", completedView]]),
+      });
+
+      const result = resolveIssue("MT-44", callbacks);
+
+      expect(result).toEqual({ kind: "completed", view: completedView });
+    });
+
+    it("finds an issue in the detail views", () => {
+      const detailView = createDetailView();
+      const callbacks = createCallbacks({
+        getDetailViews: () => new Map([["MT-45", detailView]]),
+      });
+
+      const result = resolveIssue("MT-45", callbacks);
+
+      expect(result).toEqual({ kind: "detail", view: detailView });
+    });
+
+    it("prioritizes running over retry", () => {
+      const runningEntry = createRunningEntry({ issue: createIssue({ identifier: "MT-42" }) });
+      const retryEntry = createRetryEntry({ identifier: "MT-42", issue: createIssue({ identifier: "MT-42" }) });
+      const callbacks = createCallbacks({
+        getRunningEntries: () => new Map([["run-1", runningEntry]]),
+        getRetryEntries: () => new Map([["MT-42", retryEntry]]),
+      });
+
+      const result = resolveIssue("MT-42", callbacks);
+
+      expect(result?.kind).toBe("running");
+    });
+
+    it("prioritizes retry over completed", () => {
+      const retryEntry = createRetryEntry({ identifier: "MT-44", issue: createIssue({ identifier: "MT-44" }) });
+      const completedView = createCompletedView({ identifier: "MT-44" });
+      const callbacks = createCallbacks({
+        getRetryEntries: () => new Map([["MT-44", retryEntry]]),
+        getCompletedViews: () => new Map([["MT-44", completedView]]),
+      });
+
+      const result = resolveIssue("MT-44", callbacks);
+
+      expect(result?.kind).toBe("retry");
+    });
+
+    it("prioritizes completed over detail", () => {
+      const completedView = createCompletedView({ identifier: "MT-45" });
+      const detailView = createDetailView({ identifier: "MT-45" });
+      const callbacks = createCallbacks({
+        getCompletedViews: () => new Map([["MT-45", completedView]]),
+        getDetailViews: () => new Map([["MT-45", detailView]]),
+      });
+
+      const result = resolveIssue("MT-45", callbacks);
+
+      expect(result?.kind).toBe("completed");
+    });
+
+    it("resolves running entries by issue identifier, not map key", () => {
+      const runningEntry = createRunningEntry({ issue: createIssue({ identifier: "MT-50" }) });
+      const callbacks = createCallbacks({
+        getRunningEntries: () => new Map([["arbitrary-key", runningEntry]]),
+      });
+
+      const result = resolveIssue("MT-50", callbacks);
+
+      expect(result).toEqual({ kind: "running", entry: runningEntry });
+    });
+
+    it("resolves retry entries by identifier, not map key", () => {
+      const retryEntry = createRetryEntry({ identifier: "MT-60" });
+      const callbacks = createCallbacks({
+        getRetryEntries: () => new Map([["arbitrary-key", retryEntry]]),
+      });
+
+      const result = resolveIssue("MT-60", callbacks);
+
+      expect(result).toEqual({ kind: "retry", entry: retryEntry });
+    });
+  });
+
+  describe("toIssueView", () => {
+    it("converts a running location to a RuntimeIssueView", () => {
+      const runningEntry = createRunningEntry();
+      const callbacks = createCallbacks({
+        resolveModelSelection: vi.fn().mockReturnValue(createModelSelection()),
+      });
+
+      const view = toIssueView({ kind: "running", entry: runningEntry }, callbacks);
+
+      expect(view).toMatchObject({
+        identifier: "MT-42",
+        status: "running",
+        attempt: 1,
+        workspaceKey: "MT-42",
+        model: "gpt-5.4",
+      });
+    });
+
+    it("converts a retry location to a RuntimeIssueView", () => {
+      const retryEntry = createRetryEntry();
+      const callbacks = createCallbacks({
+        resolveModelSelection: vi.fn().mockReturnValue(createModelSelection()),
+      });
+
+      const view = toIssueView({ kind: "retry", entry: retryEntry }, callbacks);
+
+      expect(view).toMatchObject({
+        identifier: "MT-43",
+        status: "retrying",
+        attempt: 2,
+        error: "turn_failed",
+      });
+    });
+
+    it("returns the view directly for a completed location", () => {
+      const completedView = createCompletedView();
+      const callbacks = createCallbacks();
+
+      const view = toIssueView({ kind: "completed", view: completedView }, callbacks);
+
+      expect(view).toBe(completedView);
+    });
+
+    it("returns the view directly for a detail location", () => {
+      const detailView = createDetailView();
+      const callbacks = createCallbacks();
+
+      const view = toIssueView({ kind: "detail", view: detailView }, callbacks);
+
+      expect(view).toBe(detailView);
+    });
+
+    it("passes the correct identifier to resolveModelSelection for running entries", () => {
+      const runningEntry = createRunningEntry({ issue: createIssue({ identifier: "MT-99" }) });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+      const callbacks = createCallbacks({ resolveModelSelection });
+
+      toIssueView({ kind: "running", entry: runningEntry }, callbacks);
+
+      expect(resolveModelSelection).toHaveBeenCalledWith("MT-99");
+    });
+
+    it("passes the correct identifier to resolveModelSelection for retry entries", () => {
+      const retryEntry = createRetryEntry({ identifier: "MT-77" });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+      const callbacks = createCallbacks({ resolveModelSelection });
+
+      toIssueView({ kind: "retry", entry: retryEntry }, callbacks);
+
+      expect(resolveModelSelection).toHaveBeenCalledWith("MT-77");
+    });
+  });
+});

--- a/tests/orchestrator/issue-test-factories.ts
+++ b/tests/orchestrator/issue-test-factories.ts
@@ -1,0 +1,109 @@
+import type { ModelSelection, RuntimeIssueView } from "../../src/core/types.js";
+import type { RunningEntry, RetryRuntimeEntry } from "../../src/orchestrator/runtime-types.js";
+
+export function createIssue(overrides?: Partial<RunningEntry["issue"]>): RunningEntry["issue"] {
+  return {
+    id: "issue-1",
+    identifier: "MT-42",
+    title: "Test Issue",
+    description: null,
+    priority: 1,
+    state: "In Progress",
+    branchName: null,
+    url: null,
+    labels: [],
+    blockedBy: [],
+    createdAt: "2026-03-15T00:00:00Z",
+    updatedAt: "2026-03-16T00:00:00Z",
+    ...overrides,
+  };
+}
+
+export function createWorkspace(overrides?: Partial<RunningEntry["workspace"]>): RunningEntry["workspace"] {
+  return {
+    path: "/tmp/symphony/MT-42",
+    workspaceKey: "MT-42",
+    createdNow: true,
+    ...overrides,
+  };
+}
+
+export function createModelSelection(overrides?: Partial<ModelSelection>): ModelSelection {
+  return {
+    model: "gpt-5.4",
+    reasoningEffort: "high",
+    source: "default",
+    ...overrides,
+  };
+}
+
+export function createRunningEntry(overrides?: Partial<RunningEntry>): RunningEntry {
+  const now = Date.now();
+  return {
+    runId: "run-1",
+    issue: createIssue(),
+    workspace: createWorkspace(),
+    startedAtMs: now - 60000,
+    lastEventAtMs: now - 30000,
+    attempt: 1,
+    abortController: new AbortController(),
+    promise: Promise.resolve(),
+    cleanupOnExit: false,
+    status: "running",
+    sessionId: "session-1",
+    tokenUsage: null,
+    modelSelection: createModelSelection(),
+    lastAgentMessageContent: null,
+    repoMatch: null,
+    queuePersistence: () => undefined,
+    flushPersistence: async () => undefined,
+    ...overrides,
+  } as RunningEntry;
+}
+
+export function createRetryEntry(overrides?: Partial<RetryRuntimeEntry>): RetryRuntimeEntry {
+  const now = Date.now();
+  return {
+    issueId: "issue-1",
+    identifier: "MT-43",
+    attempt: 2,
+    dueAtMs: now + 30000,
+    error: "turn_failed",
+    timer: null,
+    issue: createIssue({ id: "issue-1", identifier: "MT-43" }),
+    workspaceKey: "MT-43",
+    ...overrides,
+  } as RetryRuntimeEntry;
+}
+
+export function createCompletedView(overrides?: Partial<RuntimeIssueView>): RuntimeIssueView {
+  return {
+    issueId: "issue-3",
+    identifier: "MT-44",
+    title: "Completed Issue",
+    state: "Done",
+    workspaceKey: "MT-44",
+    message: "Completed successfully",
+    status: "completed",
+    updatedAt: "2026-03-16T00:00:00Z",
+    attempt: 1,
+    error: null,
+    ...overrides,
+  };
+}
+
+export function createDetailView(overrides?: Partial<RuntimeIssueView>): RuntimeIssueView {
+  return {
+    issueId: "issue-4",
+    identifier: "MT-45",
+    title: "Detail View Issue",
+    state: "In Progress",
+    workspaceKey: null,
+    message: null,
+    status: "queued",
+    updatedAt: "2026-03-16T00:00:00Z",
+    attempt: null,
+    error: null,
+    ...overrides,
+  };
+}

--- a/tests/orchestrator/issue-view-builders.test.ts
+++ b/tests/orchestrator/issue-view-builders.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildRunningIssueView, buildRetryIssueView } from "../../src/orchestrator/issue-view-builders.js";
+import { createIssue, createModelSelection, createRunningEntry, createRetryEntry } from "./issue-test-factories.js";
+
+describe("issue-view-builders", () => {
+  describe("buildRunningIssueView", () => {
+    it("converts a running entry to a RuntimeIssueView with correct fields", () => {
+      const entry = createRunningEntry();
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      const view = buildRunningIssueView(entry, resolveModelSelection);
+
+      expect(view).toMatchObject({
+        issueId: "issue-1",
+        identifier: "MT-42",
+        title: "Test Issue",
+        state: "In Progress",
+        status: "running",
+        attempt: 1,
+        workspaceKey: "MT-42",
+        workspacePath: "/tmp/symphony/MT-42",
+        model: "gpt-5.4",
+        reasoningEffort: "high",
+        modelSource: "default",
+        priority: 1,
+        labels: [],
+      });
+    });
+
+    it("sets modelChangePending to false when configured matches active", () => {
+      const entry = createRunningEntry();
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      const view = buildRunningIssueView(entry, resolveModelSelection);
+
+      expect(view.modelChangePending).toBe(false);
+    });
+
+    it("sets modelChangePending to true when configured model differs from active", () => {
+      const entry = createRunningEntry({
+        modelSelection: createModelSelection({ model: "gpt-5.4", reasoningEffort: "high" }),
+      });
+      const resolveModelSelection = vi
+        .fn()
+        .mockReturnValue(createModelSelection({ model: "gpt-5", reasoningEffort: "high" }));
+
+      const view = buildRunningIssueView(entry, resolveModelSelection);
+
+      expect(view.modelChangePending).toBe(true);
+      expect(view.configuredModel).toBe("gpt-5");
+      expect(view.model).toBe("gpt-5.4");
+    });
+
+    it("sets modelChangePending to true when configured reasoningEffort differs", () => {
+      const entry = createRunningEntry({
+        modelSelection: createModelSelection({ reasoningEffort: "high" }),
+      });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection({ reasoningEffort: "medium" }));
+
+      const view = buildRunningIssueView(entry, resolveModelSelection);
+
+      expect(view.modelChangePending).toBe(true);
+      expect(view.configuredReasoningEffort).toBe("medium");
+      expect(view.reasoningEffort).toBe("high");
+    });
+
+    it("populates configured model fields from resolveModelSelection", () => {
+      const entry = createRunningEntry();
+      const resolveModelSelection = vi
+        .fn()
+        .mockReturnValue(createModelSelection({ model: "gpt-5", reasoningEffort: "low", source: "override" }));
+
+      const view = buildRunningIssueView(entry, resolveModelSelection);
+
+      expect(view.configuredModel).toBe("gpt-5");
+      expect(view.configuredReasoningEffort).toBe("low");
+      expect(view.configuredModelSource).toBe("override");
+    });
+
+    it("includes startedAt and lastEventAt as ISO strings", () => {
+      const startedAtMs = Date.parse("2026-03-15T10:00:00Z");
+      const lastEventAtMs = Date.parse("2026-03-15T10:05:00Z");
+      const entry = createRunningEntry({ startedAtMs, lastEventAtMs });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      const view = buildRunningIssueView(entry, resolveModelSelection);
+
+      expect(view.startedAt).toBe("2026-03-15T10:00:00.000Z");
+      expect(view.lastEventAt).toBe("2026-03-15T10:05:00.000Z");
+    });
+
+    it("includes tokenUsage when present", () => {
+      const tokenUsage = { inputTokens: 100, outputTokens: 50, totalTokens: 150 };
+      const entry = createRunningEntry({ tokenUsage });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      const view = buildRunningIssueView(entry, resolveModelSelection);
+
+      expect(view.tokenUsage).toEqual(tokenUsage);
+    });
+
+    it("passes null tokenUsage when not present", () => {
+      const entry = createRunningEntry({ tokenUsage: null });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      const view = buildRunningIssueView(entry, resolveModelSelection);
+
+      expect(view.tokenUsage).toBeNull();
+    });
+
+    it("sets message to 'stopping in <path>' when status is stopping", () => {
+      const entry = createRunningEntry({ status: "stopping" });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      const view = buildRunningIssueView(entry, resolveModelSelection);
+
+      expect(view.status).toBe("stopping");
+      expect(view.message).toBe("stopping in /tmp/symphony/MT-42");
+    });
+
+    it("sets message to 'running in <path>' when status is running", () => {
+      const entry = createRunningEntry({ status: "running" });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      const view = buildRunningIssueView(entry, resolveModelSelection);
+
+      expect(view.message).toBe("running in /tmp/symphony/MT-42");
+    });
+
+    it("calls resolveModelSelection with the entry identifier", () => {
+      const entry = createRunningEntry({ issue: createIssue({ identifier: "MT-99" }) });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      buildRunningIssueView(entry, resolveModelSelection);
+
+      expect(resolveModelSelection).toHaveBeenCalledWith("MT-99");
+    });
+  });
+
+  describe("buildRetryIssueView", () => {
+    it("converts a retry entry to a RuntimeIssueView with correct fields", () => {
+      const entry = createRetryEntry();
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      const view = buildRetryIssueView(entry, resolveModelSelection);
+
+      expect(view).toMatchObject({
+        issueId: "issue-1",
+        identifier: "MT-43",
+        status: "retrying",
+        attempt: 2,
+        error: "turn_failed",
+        workspaceKey: "MT-43",
+        model: "gpt-5.4",
+        reasoningEffort: "high",
+        modelSource: "default",
+      });
+    });
+
+    it("always sets modelChangePending to false", () => {
+      const entry = createRetryEntry();
+      const resolveModelSelection = vi
+        .fn()
+        .mockReturnValue(createModelSelection({ model: "gpt-5", reasoningEffort: "low", source: "override" }));
+
+      const view = buildRetryIssueView(entry, resolveModelSelection);
+
+      expect(view.modelChangePending).toBe(false);
+    });
+
+    it("sets message with retry due timestamp", () => {
+      const dueAtMs = Date.parse("2026-03-15T12:00:00Z");
+      const entry = createRetryEntry({ dueAtMs });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      const view = buildRetryIssueView(entry, resolveModelSelection);
+
+      expect(view.message).toBe("retry due at 2026-03-15T12:00:00.000Z");
+    });
+
+    it("sets nextRetryDueAt to the ISO string of dueAtMs", () => {
+      const dueAtMs = Date.parse("2026-03-15T12:00:00Z");
+      const entry = createRetryEntry({ dueAtMs });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      const view = buildRetryIssueView(entry, resolveModelSelection);
+
+      expect(view.nextRetryDueAt).toBe("2026-03-15T12:00:00.000Z");
+    });
+
+    it("uses configured model fields from resolveModelSelection for both model and configured fields", () => {
+      const entry = createRetryEntry();
+      const configured = createModelSelection({ model: "gpt-5", reasoningEffort: "low", source: "override" });
+      const resolveModelSelection = vi.fn().mockReturnValue(configured);
+
+      const view = buildRetryIssueView(entry, resolveModelSelection);
+
+      expect(view.configuredModel).toBe("gpt-5");
+      expect(view.configuredReasoningEffort).toBe("low");
+      expect(view.configuredModelSource).toBe("override");
+      expect(view.model).toBe("gpt-5");
+      expect(view.reasoningEffort).toBe("low");
+      expect(view.modelSource).toBe("override");
+    });
+
+    it("calls resolveModelSelection with the entry identifier", () => {
+      const entry = createRetryEntry({ identifier: "MT-77" });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      buildRetryIssueView(entry, resolveModelSelection);
+
+      expect(resolveModelSelection).toHaveBeenCalledWith("MT-77");
+    });
+
+    it("includes error from retry entry", () => {
+      const entry = createRetryEntry({ error: "startup_failed" });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      const view = buildRetryIssueView(entry, resolveModelSelection);
+
+      expect(view.error).toBe("startup_failed");
+    });
+
+    it("handles null error in retry entry", () => {
+      const entry = createRetryEntry({ error: null });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      const view = buildRetryIssueView(entry, resolveModelSelection);
+
+      expect(view.error).toBeNull();
+    });
+
+    it("handles null workspaceKey in retry entry", () => {
+      const entry = createRetryEntry({ workspaceKey: null });
+      const resolveModelSelection = vi.fn().mockReturnValue(createModelSelection());
+
+      const view = buildRetryIssueView(entry, resolveModelSelection);
+
+      expect(view.workspaceKey).toBeNull();
+    });
+  });
+});

--- a/tests/orchestrator/lifecycle-events.test.ts
+++ b/tests/orchestrator/lifecycle-events.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { createLifecycleEvent, toErrorMessage } from "../../src/orchestrator/lifecycle-events.js";
+
+describe("lifecycle-events", () => {
+  describe("createLifecycleEvent", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-03-15T10:00:00Z"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("creates an event with all required fields", () => {
+      const event = createLifecycleEvent({
+        issue: { id: "issue-1", identifier: "MT-42" },
+        event: "worker_started",
+        message: "Worker started for MT-42",
+      });
+
+      expect(event).toEqual({
+        at: "2026-03-15T10:00:00.000Z",
+        issueId: "issue-1",
+        issueIdentifier: "MT-42",
+        sessionId: null,
+        event: "worker_started",
+        message: "Worker started for MT-42",
+        metadata: null,
+      });
+    });
+
+    it("uses the provided 'at' timestamp instead of current time", () => {
+      const event = createLifecycleEvent({
+        issue: { id: "issue-1", identifier: "MT-42" },
+        event: "worker_completed",
+        message: "Worker completed",
+        at: "2026-03-14T08:00:00Z",
+      });
+
+      expect(event.at).toBe("2026-03-14T08:00:00Z");
+    });
+
+    it("defaults 'at' to current time when not provided", () => {
+      const event = createLifecycleEvent({
+        issue: { id: "issue-1", identifier: "MT-42" },
+        event: "worker_started",
+        message: "Worker started",
+      });
+
+      expect(event.at).toBe("2026-03-15T10:00:00.000Z");
+    });
+
+    it("includes sessionId when provided", () => {
+      const event = createLifecycleEvent({
+        issue: { id: "issue-1", identifier: "MT-42" },
+        event: "worker_started",
+        message: "Worker started",
+        sessionId: "session-abc",
+      });
+
+      expect(event.sessionId).toBe("session-abc");
+    });
+
+    it("defaults sessionId to null when not provided", () => {
+      const event = createLifecycleEvent({
+        issue: { id: "issue-1", identifier: "MT-42" },
+        event: "worker_started",
+        message: "Worker started",
+      });
+
+      expect(event.sessionId).toBeNull();
+    });
+
+    it("defaults sessionId to null when explicitly null", () => {
+      const event = createLifecycleEvent({
+        issue: { id: "issue-1", identifier: "MT-42" },
+        event: "worker_started",
+        message: "Worker started",
+        sessionId: null,
+      });
+
+      expect(event.sessionId).toBeNull();
+    });
+
+    it("includes metadata when provided", () => {
+      const metadata = { attempt: 3, errorCode: "turn_failed" };
+      const event = createLifecycleEvent({
+        issue: { id: "issue-1", identifier: "MT-42" },
+        event: "retry_scheduled",
+        message: "Retry scheduled",
+        metadata,
+      });
+
+      expect(event.metadata).toEqual(metadata);
+    });
+
+    it("defaults metadata to null when not provided", () => {
+      const event = createLifecycleEvent({
+        issue: { id: "issue-1", identifier: "MT-42" },
+        event: "worker_started",
+        message: "Worker started",
+      });
+
+      expect(event.metadata).toBeNull();
+    });
+
+    it("defaults metadata to null when explicitly null", () => {
+      const event = createLifecycleEvent({
+        issue: { id: "issue-1", identifier: "MT-42" },
+        event: "worker_started",
+        message: "Worker started",
+        metadata: null,
+      });
+
+      expect(event.metadata).toBeNull();
+    });
+
+    it("preserves issue id and identifier exactly as given", () => {
+      const event = createLifecycleEvent({
+        issue: { id: "abc-def-123", identifier: "PROJ-999" },
+        event: "test_event",
+        message: "Test message",
+      });
+
+      expect(event.issueId).toBe("abc-def-123");
+      expect(event.issueIdentifier).toBe("PROJ-999");
+    });
+
+    it("preserves the event type string exactly as given", () => {
+      const event = createLifecycleEvent({
+        issue: { id: "issue-1", identifier: "MT-42" },
+        event: "custom_event_type",
+        message: "Something happened",
+      });
+
+      expect(event.event).toBe("custom_event_type");
+    });
+  });
+
+  describe("toErrorMessage", () => {
+    it("extracts message from an Error instance", () => {
+      const result = toErrorMessage(new Error("something went wrong"));
+      expect(result).toBe("something went wrong");
+    });
+
+    it("extracts message from a TypeError instance", () => {
+      const result = toErrorMessage(new TypeError("invalid type"));
+      expect(result).toBe("invalid type");
+    });
+
+    it("converts a string to its string representation", () => {
+      const result = toErrorMessage("plain string error");
+      expect(result).toBe("plain string error");
+    });
+
+    it("converts a number to its string representation", () => {
+      const result = toErrorMessage(42);
+      expect(result).toBe("42");
+    });
+
+    it("converts null to its string representation", () => {
+      const result = toErrorMessage(null);
+      expect(result).toBe("null");
+    });
+
+    it("converts undefined to its string representation", () => {
+      const result = toErrorMessage(undefined);
+      expect(result).toBe("undefined");
+    });
+
+    it("converts an object to its string representation", () => {
+      const result = toErrorMessage({ code: "ERR" });
+      expect(result).toBe("[object Object]");
+    });
+
+    it("converts a boolean to its string representation", () => {
+      const result = toErrorMessage(false);
+      expect(result).toBe("false");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `src/orchestrator/issue-locator.ts` (resolveIssue priority-ordered lookup, toIssueView conversion)
- Add unit tests for `src/orchestrator/issue-view-builders.ts` (buildRunningIssueView model-change-pending detection, buildRetryIssueView retry state rendering)
- Add unit tests for `src/orchestrator/lifecycle-events.ts` (createLifecycleEvent with correct types/timestamps, toErrorMessage formatting)
- Extract shared test factories into `tests/orchestrator/issue-test-factories.ts` to avoid duplication across test files

## Test plan
- [x] All 55 new tests pass (`npm test -- tests/orchestrator/issue-locator.test.ts tests/orchestrator/issue-view-builders.test.ts tests/orchestrator/lifecycle-events.test.ts`)
- [x] Full test suite passes (927 tests, 0 failures)
- [x] Build, lint, and format checks pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
