### PR TITLE
test(config): add resolvers, workflow loader, and columns tests

### DIFF
--- a/tests/config/resolvers.test.ts
+++ b/tests/config/resolvers.test.ts
@@ -1,0 +1,151 @@
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveConfigString, resolvePathConfigString } from "../../src/config/resolvers.js";
+
+let originalEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  originalEnv = { ...process.env };
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+describe("resolveConfigString", () => {
+  describe("literal values", () => {
+    it("returns a plain string as-is", () => {
+      expect(resolveConfigString("hello")).toBe("hello");
+    });
+
+    it("returns empty string for non-string inputs", () => {
+      expect(resolveConfigString(undefined)).toBe("");
+      expect(resolveConfigString(null)).toBe("");
+      expect(resolveConfigString(42)).toBe("");
+      expect(resolveConfigString({})).toBe("");
+    });
+  });
+
+  describe("$VAR expansion", () => {
+    it("resolves a $VAR reference from process.env", () => {
+      process.env.SYMPHONY_TEST_VAR = "resolved-value";
+      expect(resolveConfigString("$SYMPHONY_TEST_VAR")).toBe("resolved-value");
+    });
+
+    it("returns empty string when the env var is missing", () => {
+      delete process.env.SYMPHONY_MISSING_VAR;
+      expect(resolveConfigString("$SYMPHONY_MISSING_VAR")).toBe("");
+    });
+
+    it("does not expand vars embedded in longer strings", () => {
+      process.env.SYMPHONY_TEST_VAR = "val";
+      expect(resolveConfigString("prefix-$SYMPHONY_TEST_VAR")).toBe("prefix-$SYMPHONY_TEST_VAR");
+    });
+
+    it("does not expand invalid var names", () => {
+      expect(resolveConfigString("$123invalid")).toBe("$123invalid");
+    });
+  });
+
+  describe("$SECRET:name expansion", () => {
+    it("resolves a secret via the secretResolver callback", () => {
+      const resolver = (name: string) => (name === "my-key" ? "secret-val" : undefined);
+      expect(resolveConfigString("$SECRET:my-key", resolver)).toBe("secret-val");
+    });
+
+    it("returns empty string when secretResolver returns undefined", () => {
+      const resolver = () => undefined;
+      expect(resolveConfigString("$SECRET:unknown", resolver)).toBe("");
+    });
+
+    it("returns empty string when no secretResolver is provided", () => {
+      expect(resolveConfigString("$SECRET:some-key")).toBe("");
+    });
+
+    it("supports dots and hyphens in secret names", () => {
+      const resolver = (name: string) => (name === "my.secret-name" ? "found" : undefined);
+      expect(resolveConfigString("$SECRET:my.secret-name", resolver)).toBe("found");
+    });
+  });
+
+  describe("home path (~) expansion", () => {
+    it("expands bare ~ to HOME", () => {
+      process.env.HOME = "/home/testuser";
+      expect(resolveConfigString("~")).toBe("/home/testuser");
+    });
+
+    it("expands ~/ prefix with HOME", () => {
+      process.env.HOME = "/home/testuser";
+      expect(resolveConfigString("~/docs")).toBe(path.join("/home/testuser", "docs"));
+    });
+
+    it("falls back to ~ when HOME is not set", () => {
+      delete process.env.HOME;
+      expect(resolveConfigString("~")).toBe("~");
+    });
+  });
+
+  describe("$TMPDIR expansion", () => {
+    it("replaces $TMPDIR with the actual temp directory", () => {
+      process.env.TMPDIR = "/custom/tmp";
+      expect(resolveConfigString("$TMPDIR")).toBe("/custom/tmp");
+    });
+
+    it("returns empty string when TMPDIR env is not set", () => {
+      delete process.env.TMPDIR;
+      // env resolution consumes "$TMPDIR" first; $TMPDIR replacement is for inline usage
+      expect(resolveConfigString("$TMPDIR")).toBe("");
+    });
+  });
+
+  describe("chained resolution", () => {
+    it("resolves env var then applies tmpdir expansion on the result", () => {
+      process.env.SYMPHONY_PATH = "/base/$TMPDIR/sub";
+      process.env.TMPDIR = "/tmp";
+      expect(resolveConfigString("$SYMPHONY_PATH")).toBe("/base//tmp/sub");
+    });
+
+    it("resolves home path then tmpdir in a chained value", () => {
+      process.env.HOME = "/home/user";
+      expect(resolveConfigString("~/workspace")).toBe(path.join("/home/user", "workspace"));
+    });
+  });
+});
+
+describe("resolvePathConfigString", () => {
+  it("returns empty string for non-string inputs", () => {
+    expect(resolvePathConfigString(undefined)).toBe("");
+    expect(resolvePathConfigString(null)).toBe("");
+    expect(resolvePathConfigString(42)).toBe("");
+  });
+
+  it("expands all $VAR references within a path string", () => {
+    process.env.SYMPHONY_BASE = "base";
+    process.env.SYMPHONY_SUB = "sub";
+    expect(resolvePathConfigString("/root/$SYMPHONY_BASE/$SYMPHONY_SUB/file")).toBe("/root/base/sub/file");
+  });
+
+  it("expands $TMPDIR inline within a path", () => {
+    process.env.TMPDIR = "/custom/tmp";
+    expect(resolvePathConfigString("/prefix/$TMPDIR/suffix")).toBe("/prefix//custom/tmp/suffix");
+  });
+
+  it("expands ~ and then remaining env vars in a path", () => {
+    process.env.HOME = "/home/user";
+    process.env.SYMPHONY_DIR = "proj";
+    expect(resolvePathConfigString("~/$SYMPHONY_DIR/src")).toBe(path.join("/home/user", "proj/src"));
+  });
+
+  it("resolves secrets before path expansion", () => {
+    const resolver = (name: string) => (name === "path-secret" ? "/secret/base/$SYMPHONY_EXTRA" : undefined);
+    process.env.SYMPHONY_EXTRA = "extra";
+    expect(resolvePathConfigString("$SECRET:path-secret", resolver)).toBe("/secret/base/extra");
+  });
+
+  it("replaces missing env vars with empty string in paths", () => {
+    delete process.env.SYMPHONY_NOPE;
+    expect(resolvePathConfigString("/a/$SYMPHONY_NOPE/b")).toBe("/a//b");
+  });
+});

--- a/tests/workflow/columns.test.ts
+++ b/tests/workflow/columns.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "vitest";
+
+import { buildWorkflowColumns } from "../../src/workflow/columns.js";
+import type { RuntimeIssueView, ServiceConfig } from "../../src/core/types.js";
+
+function makeIssueView(overrides: Partial<RuntimeIssueView>): RuntimeIssueView {
+  return {
+    issueId: "issue-1",
+    identifier: "TEST-1",
+    title: "Test issue",
+    state: "Todo",
+    workspaceKey: null,
+    message: null,
+    status: "queued",
+    updatedAt: "2025-01-01T00:00:00Z",
+    attempt: null,
+    error: null,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides?: Partial<ServiceConfig>): ServiceConfig {
+  return {
+    tracker: {
+      kind: "linear",
+      apiKey: "test-key",
+      endpoint: "https://api.linear.app/graphql",
+      projectSlug: "TEST",
+      activeStates: ["Todo", "In Progress"],
+      terminalStates: ["Done", "Canceled"],
+    },
+    polling: { intervalMs: 30000 },
+    workspace: {
+      root: "/tmp/workspaces",
+      hooks: {
+        afterCreate: null,
+        beforeRun: null,
+        afterRun: null,
+        beforeRemove: null,
+        timeoutMs: 60000,
+      },
+      strategy: "directory",
+      branchPrefix: "symphony/",
+    },
+    agent: {
+      maxConcurrentAgents: 2,
+      maxConcurrentAgentsByState: {},
+      maxTurns: 10,
+      maxRetryBackoffMs: 300000,
+      maxContinuationAttempts: 3,
+      successState: null,
+      stallTimeoutMs: 600000,
+    },
+    codex: {
+      command: "codex",
+      model: "gpt-4",
+      reasoningEffort: "medium",
+      auth: { mode: "api_key", sourceHome: "" },
+      provider: null,
+      sandbox: null,
+    } as ServiceConfig["codex"],
+    server: { port: 4000 },
+    ...overrides,
+  };
+}
+
+describe("buildWorkflowColumns", () => {
+  describe("column structure from config", () => {
+    it("creates columns for all active and terminal states", () => {
+      const config = makeConfig();
+      const columns = buildWorkflowColumns(config, {
+        running: [],
+        retrying: [],
+      });
+
+      expect(columns).toHaveLength(4);
+      expect(columns.map((col) => col.key)).toEqual(["todo", "in progress", "done", "canceled"]);
+    });
+
+    it("sets correct kind and terminal flags", () => {
+      const config = makeConfig();
+      const columns = buildWorkflowColumns(config, {
+        running: [],
+        retrying: [],
+      });
+
+      const todoColumn = columns.find((col) => col.key === "todo");
+      expect(todoColumn?.kind).toBe("todo");
+      expect(todoColumn?.terminal).toBe(false);
+
+      const doneColumn = columns.find((col) => col.key === "done");
+      expect(doneColumn?.kind).toBe("terminal");
+      expect(doneColumn?.terminal).toBe(true);
+    });
+
+    it("initializes all columns with zero counts and empty issue arrays", () => {
+      const config = makeConfig();
+      const columns = buildWorkflowColumns(config, {
+        running: [],
+        retrying: [],
+      });
+
+      for (const column of columns) {
+        expect(column.count).toBe(0);
+        expect(column.issues).toEqual([]);
+      }
+    });
+  });
+
+  describe("issue placement", () => {
+    it("places issues into the correct column by normalized state", () => {
+      const config = makeConfig();
+      const running = [makeIssueView({ issueId: "r1", identifier: "T-1", state: "In Progress" })];
+      const queued = [makeIssueView({ issueId: "q1", identifier: "T-2", state: "Todo" })];
+
+      const columns = buildWorkflowColumns(config, {
+        running,
+        retrying: [],
+        queued,
+      });
+
+      const inProgressCol = columns.find((col) => col.key === "in progress");
+      expect(inProgressCol?.count).toBe(1);
+      expect(inProgressCol?.issues).toHaveLength(1);
+      expect(inProgressCol?.issues[0].identifier).toBe("T-1");
+
+      const todoCol = columns.find((col) => col.key === "todo");
+      expect(todoCol?.count).toBe(1);
+      expect(todoCol?.issues[0].identifier).toBe("T-2");
+    });
+
+    it("places completed issues into terminal columns", () => {
+      const config = makeConfig();
+      const completed = [makeIssueView({ issueId: "c1", identifier: "T-3", state: "Done" })];
+
+      const columns = buildWorkflowColumns(config, {
+        running: [],
+        retrying: [],
+        completed,
+      });
+
+      const doneCol = columns.find((col) => col.key === "done");
+      expect(doneCol?.count).toBe(1);
+      expect(doneCol?.issues[0].identifier).toBe("T-3");
+    });
+  });
+
+  describe("deduplication", () => {
+    it("deduplicates issues with the same identifier across groups", () => {
+      const config = makeConfig();
+      const issue = makeIssueView({ issueId: "dup-1", identifier: "T-1", state: "In Progress" });
+
+      const columns = buildWorkflowColumns(config, {
+        running: [issue],
+        retrying: [{ ...issue }],
+        queued: [{ ...issue, state: "Todo" }],
+      });
+
+      const totalIssues = columns.reduce((sum, col) => sum + col.count, 0);
+      expect(totalIssues).toBe(1);
+    });
+
+    it("deduplicates by issueId when identifier is empty", () => {
+      const config = makeConfig();
+      const issue = makeIssueView({
+        issueId: "dup-id",
+        identifier: "",
+        state: "Todo",
+      });
+
+      const columns = buildWorkflowColumns(config, {
+        running: [issue],
+        retrying: [{ ...issue }],
+      });
+
+      const totalIssues = columns.reduce((sum, col) => sum + col.count, 0);
+      expect(totalIssues).toBe(1);
+    });
+
+    it("skips issues with no identifier and no issueId", () => {
+      const config = makeConfig();
+      const issue = makeIssueView({
+        issueId: "",
+        identifier: "",
+        state: "Todo",
+      });
+
+      const columns = buildWorkflowColumns(config, {
+        running: [issue],
+        retrying: [],
+      });
+
+      const totalIssues = columns.reduce((sum, col) => sum + col.count, 0);
+      expect(totalIssues).toBe(0);
+    });
+  });
+
+  describe("other bucket handling", () => {
+    it("creates an 'other' column for issues with unknown states", () => {
+      const config = makeConfig();
+      const running = [makeIssueView({ issueId: "o1", identifier: "T-1", state: "Unknown State" })];
+
+      const columns = buildWorkflowColumns(config, {
+        running,
+        retrying: [],
+      });
+
+      const otherCol = columns.find((col) => col.key === "other");
+      expect(otherCol).toBeDefined();
+      expect(otherCol?.label).toBe("Other");
+      expect(otherCol?.kind).toBe("other");
+      expect(otherCol?.terminal).toBe(false);
+      expect(otherCol?.count).toBe(1);
+      expect(otherCol?.issues[0].identifier).toBe("T-1");
+    });
+
+    it("does not create 'other' column when all issues map to known states", () => {
+      const config = makeConfig();
+      const running = [makeIssueView({ issueId: "k1", identifier: "T-1", state: "Todo" })];
+
+      const columns = buildWorkflowColumns(config, {
+        running,
+        retrying: [],
+      });
+
+      const otherCol = columns.find((col) => col.key === "other");
+      expect(otherCol).toBeUndefined();
+    });
+
+    it("places 'other' column at the end", () => {
+      const config = makeConfig();
+      const running = [
+        makeIssueView({ issueId: "k1", identifier: "T-1", state: "Todo" }),
+        makeIssueView({ issueId: "o1", identifier: "T-2", state: "Weird State" }),
+      ];
+
+      const columns = buildWorkflowColumns(config, {
+        running,
+        retrying: [],
+      });
+
+      const lastColumn = columns.at(-1);
+      expect(lastColumn?.key).toBe("other");
+    });
+  });
+
+  describe("state machine config", () => {
+    it("uses stateMachine stages when configured", () => {
+      const config = makeConfig({
+        stateMachine: {
+          stages: [
+            { name: "Backlog", kind: "backlog" },
+            { name: "Ready", kind: "todo" },
+            { name: "Working", kind: "active" },
+            { name: "Review", kind: "gate" },
+            { name: "Shipped", kind: "terminal" },
+          ],
+          transitions: {},
+        },
+      });
+
+      const columns = buildWorkflowColumns(config, {
+        running: [],
+        retrying: [],
+      });
+
+      expect(columns.map((col) => col.key)).toEqual(["backlog", "ready", "working", "review", "shipped"]);
+
+      const backlogCol = columns.find((col) => col.key === "backlog");
+      expect(backlogCol?.kind).toBe("backlog");
+      expect(backlogCol?.terminal).toBe(false);
+
+      const shippedCol = columns.find((col) => col.key === "shipped");
+      expect(shippedCol?.kind).toBe("terminal");
+      expect(shippedCol?.terminal).toBe(true);
+    });
+  });
+});

--- a/tests/workflow/loader.test.ts
+++ b/tests/workflow/loader.test.ts
@@ -1,0 +1,152 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadWorkflowDefinition } from "../../src/workflow/loader.js";
+
+const tempDirs: string[] = [];
+const baseTmpDir = os.tmpdir();
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(baseTmpDir, "symphony-loader-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("loadWorkflowDefinition", () => {
+  describe("plain text (no YAML front matter)", () => {
+    it("returns the entire content as promptTemplate with empty config", async () => {
+      const dir = await createTempDir();
+      const filePath = path.join(dir, "WORKFLOW.md");
+      await writeFile(filePath, "Hello world\nSecond line\n", "utf8");
+
+      const result = await loadWorkflowDefinition(filePath);
+
+      expect(result.config).toEqual({});
+      expect(result.promptTemplate).toBe("Hello world\nSecond line");
+    });
+
+    it("trims whitespace from plain text content", async () => {
+      const dir = await createTempDir();
+      const filePath = path.join(dir, "WORKFLOW.md");
+      await writeFile(filePath, "  \n  Some prompt  \n  \n", "utf8");
+
+      const result = await loadWorkflowDefinition(filePath);
+
+      expect(result.promptTemplate).toBe("Some prompt");
+    });
+  });
+
+  describe("YAML front matter", () => {
+    it("parses front matter and separates the prompt body", async () => {
+      const dir = await createTempDir();
+      const filePath = path.join(dir, "WORKFLOW.md");
+      await writeFile(filePath, "---\ntracker:\n  api_key: test-key\n---\nPrompt body here\n", "utf8");
+
+      const result = await loadWorkflowDefinition(filePath);
+
+      expect(result.config).toEqual({ tracker: { api_key: "test-key" } });
+      expect(result.promptTemplate).toBe("Prompt body here");
+    });
+
+    it("handles empty body after front matter", async () => {
+      const dir = await createTempDir();
+      const filePath = path.join(dir, "WORKFLOW.md");
+      await writeFile(filePath, "---\nkey: value\n---\n", "utf8");
+
+      const result = await loadWorkflowDefinition(filePath);
+
+      expect(result.config).toEqual({ key: "value" });
+      expect(result.promptTemplate).toBe("");
+    });
+
+    it("handles front matter with no trailing content after closing ---", async () => {
+      const dir = await createTempDir();
+      const filePath = path.join(dir, "WORKFLOW.md");
+      await writeFile(filePath, "---\nkey: value\n---", "utf8");
+
+      const result = await loadWorkflowDefinition(filePath);
+
+      expect(result.config).toEqual({ key: "value" });
+      expect(result.promptTemplate).toBe("");
+    });
+
+    it("preserves Liquid-compatible template syntax in the body", async () => {
+      const dir = await createTempDir();
+      const filePath = path.join(dir, "WORKFLOW.md");
+      await writeFile(filePath, "---\nmodel: gpt-4\n---\nFix {{ issue.identifier }}: {{ issue.title }}\n", "utf8");
+
+      const result = await loadWorkflowDefinition(filePath);
+
+      expect(result.promptTemplate).toBe("Fix {{ issue.identifier }}: {{ issue.title }}");
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws missing_workflow_file for a nonexistent file", async () => {
+      await expect(loadWorkflowDefinition("/nonexistent/WORKFLOW.md")).rejects.toMatchObject({
+        name: "WorkflowLoaderError",
+        validationError: { code: "missing_workflow_file" },
+      });
+    });
+
+    it("throws workflow_parse_error for unclosed front matter (no closing ---)", async () => {
+      const dir = await createTempDir();
+      const filePath = path.join(dir, "WORKFLOW.md");
+      await writeFile(filePath, "---\nkey: value\nmore: stuff\n", "utf8");
+
+      await expect(loadWorkflowDefinition(filePath)).rejects.toMatchObject({
+        validationError: {
+          code: "workflow_parse_error",
+          message: "workflow front matter is not closed with a terminating --- line",
+        },
+      });
+    });
+
+    it("throws workflow_parse_error when front matter is just --- with no newline", async () => {
+      const dir = await createTempDir();
+      const filePath = path.join(dir, "WORKFLOW.md");
+      await writeFile(filePath, "---", "utf8");
+
+      await expect(loadWorkflowDefinition(filePath)).rejects.toMatchObject({
+        validationError: { code: "workflow_parse_error" },
+      });
+    });
+
+    it("throws workflow_front_matter_not_a_map when front matter is a scalar", async () => {
+      const dir = await createTempDir();
+      const filePath = path.join(dir, "WORKFLOW.md");
+      await writeFile(filePath, "---\njust a string\n---\nBody\n", "utf8");
+
+      await expect(loadWorkflowDefinition(filePath)).rejects.toMatchObject({
+        validationError: { code: "workflow_front_matter_not_a_map" },
+      });
+    });
+
+    it("throws workflow_front_matter_not_a_map when front matter is an array", async () => {
+      const dir = await createTempDir();
+      const filePath = path.join(dir, "WORKFLOW.md");
+      await writeFile(filePath, "---\n- item1\n- item2\n---\nBody\n", "utf8");
+
+      await expect(loadWorkflowDefinition(filePath)).rejects.toMatchObject({
+        validationError: { code: "workflow_front_matter_not_a_map" },
+      });
+    });
+
+    it("throws workflow_parse_error for invalid YAML syntax", async () => {
+      const dir = await createTempDir();
+      const filePath = path.join(dir, "WORKFLOW.md");
+      await writeFile(filePath, "---\ninvalid: [\n---\nBody\n", "utf8");
+
+      await expect(loadWorkflowDefinition(filePath)).rejects.toMatchObject({
+        validationError: { code: "workflow_parse_error" },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `src/config/resolvers.ts` covering `resolveConfigString` and `resolvePathConfigString` — `$SECRET:name`, `$VAR`, `~` expansion, `$TMPDIR`, chained resolution, and missing variable handling
- Add unit tests for `src/workflow/loader.ts` covering plain text workflows, YAML front matter parsing, unclosed front matter, parse errors, scalar/array front matter rejection, and Liquid template preservation
- Add unit tests for `src/workflow/columns.ts` covering column grouping from state config, issue placement by normalized state, deduplication across groups, "other" bucket handling, and state machine stage support

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm run format:check` passes
- [x] `npm test` passes — 47 new tests across 3 files, all green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
