### PR TITLE
test(orchestrator): add worker-launcher and worker-failure tests

### DIFF
--- a/tests/orchestrator/worker-failure.test.ts
+++ b/tests/orchestrator/worker-failure.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { handleWorkerFailure } from "../../src/orchestrator/worker-failure.js";
+import { TokenRefreshError } from "../../src/codex/token-refresh.js";
+import type { Issue } from "../../src/core/types.js";
+import type { RunningEntry } from "../../src/orchestrator/runtime-types.js";
+import type { WorkerFailureContext } from "../../src/orchestrator/worker-failure.js";
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: "issue-1",
+    identifier: "MT-1",
+    title: "Test issue",
+    description: null,
+    priority: 1,
+    state: "In Progress",
+    branchName: null,
+    url: null,
+    labels: [],
+    blockedBy: [],
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+function makeEntry(overrides: Partial<RunningEntry> = {}): RunningEntry {
+  return {
+    runId: "run-abc",
+    issue: makeIssue(),
+    workspace: { path: "/tmp/ws/MT-1", workspaceKey: "ws-key", createdNow: true },
+    startedAtMs: Date.now() - 5000,
+    lastEventAtMs: Date.now(),
+    attempt: 1,
+    abortController: new AbortController(),
+    promise: Promise.resolve(),
+    cleanupOnExit: false,
+    status: "running",
+    sessionId: "sess-xyz",
+    tokenUsage: null,
+    modelSelection: { model: "gpt-4o", reasoningEffort: "high", source: "default" },
+    lastAgentMessageContent: null,
+    repoMatch: null,
+    queuePersistence: () => undefined,
+    flushPersistence: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as RunningEntry;
+}
+
+function makeCtx(
+  overrides: {
+    updateAttempt?: ReturnType<typeof vi.fn>;
+  } = {},
+): {
+  ctx: WorkerFailureContext;
+  runningEntries: Map<string, RunningEntry>;
+  releaseIssueClaim: ReturnType<typeof vi.fn>;
+  pushEvent: ReturnType<typeof vi.fn>;
+  updateAttempt: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+} {
+  const runningEntries = new Map<string, RunningEntry>();
+  const releaseIssueClaim = vi.fn();
+  const pushEvent = vi.fn();
+  const updateAttempt = overrides.updateAttempt ?? vi.fn().mockResolvedValue(undefined);
+  const warn = vi.fn();
+
+  const ctx: WorkerFailureContext = {
+    runningEntries,
+    releaseIssueClaim,
+    pushEvent,
+    deps: {
+      attemptStore: { updateAttempt },
+      logger: { warn },
+    },
+  };
+
+  return { ctx, runningEntries, releaseIssueClaim, pushEvent, updateAttempt, warn };
+}
+
+// ---------------------------------------------------------------------------
+// Core behavior: cleanup and event emission
+// ---------------------------------------------------------------------------
+
+describe("handleWorkerFailure - core behavior", () => {
+  it("removes running entry, releases claim, and pushes worker_failed event", async () => {
+    const { ctx, runningEntries, releaseIssueClaim, pushEvent, updateAttempt } = makeCtx();
+    const entry = makeEntry();
+    runningEntries.set("issue-1", entry);
+
+    await handleWorkerFailure(ctx, makeIssue(), entry, new Error("boom"));
+
+    expect(runningEntries.has("issue-1")).toBe(false);
+    expect(releaseIssueClaim).toHaveBeenCalledWith("issue-1");
+    expect(pushEvent).toHaveBeenCalledWith(expect.objectContaining({ event: "worker_failed", message: "Error: boom" }));
+    expect(updateAttempt).toHaveBeenCalledWith(
+      "run-abc",
+      expect.objectContaining({ status: "failed", errorCode: "worker_failed" }),
+    );
+  });
+
+  it("stringifies non-Error thrown values in the event message", async () => {
+    const { ctx, runningEntries, pushEvent } = makeCtx();
+    const entry = makeEntry();
+    runningEntries.set("issue-1", entry);
+
+    await handleWorkerFailure(ctx, makeIssue(), entry, "string error");
+
+    expect(pushEvent).toHaveBeenCalledWith(expect.objectContaining({ message: "string error" }));
+  });
+
+  it("includes session id, token usage, and null threadId in the attempt update", async () => {
+    const { ctx, runningEntries, updateAttempt } = makeCtx();
+    const tokenUsage = { input: 100, output: 50, total: 150 };
+    const entry = makeEntry({ sessionId: "sess-123", tokenUsage });
+    runningEntries.set("issue-1", entry);
+
+    await handleWorkerFailure(ctx, makeIssue(), entry, new Error("crash"));
+
+    expect(updateAttempt).toHaveBeenCalledWith(
+      "run-abc",
+      expect.objectContaining({
+        tokenUsage,
+        threadId: null,
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TokenRefreshError handling
+// ---------------------------------------------------------------------------
+
+describe("handleWorkerFailure - TokenRefreshError", () => {
+  it("uses the TokenRefreshError code instead of generic worker_failed", async () => {
+    const { ctx, runningEntries, updateAttempt } = makeCtx();
+    const entry = makeEntry();
+    runningEntries.set("issue-1", entry);
+
+    const tokenError = new TokenRefreshError("token_expired", "Token has expired");
+    await handleWorkerFailure(ctx, makeIssue(), entry, tokenError);
+
+    expect(updateAttempt).toHaveBeenCalledWith("run-abc", expect.objectContaining({ errorCode: "token_expired" }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flush-failure fallback chain
+// ---------------------------------------------------------------------------
+
+describe("handleWorkerFailure - flush persistence fallback", () => {
+  it("logs a warning and attempts fallback when flushPersistence rejects", async () => {
+    const { ctx, runningEntries, warn, updateAttempt } = makeCtx();
+    const entry = makeEntry({
+      flushPersistence: vi.fn().mockRejectedValue(new Error("flush failed")),
+    });
+    runningEntries.set("issue-1", entry);
+
+    await handleWorkerFailure(ctx, makeIssue(), entry, new Error("crash"));
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "Error: flush failed" }),
+      expect.stringContaining("failed to flush persistence"),
+    );
+    // Should still attempt the regular status update afterward
+    expect(updateAttempt).toHaveBeenCalledWith("run-abc", expect.objectContaining({ errorCode: "flush_failed" }));
+  });
+
+  it("logs both warnings when flush and fallback both fail", async () => {
+    const updateAttempt = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("fallback flush failed")) // flush fallback
+      .mockRejectedValueOnce(new Error("status update failed")) // status update
+      .mockRejectedValueOnce(new Error("status fallback failed")); // status fallback
+    const { ctx, runningEntries, warn } = makeCtx({ updateAttempt });
+    const entry = makeEntry({
+      flushPersistence: vi.fn().mockRejectedValue(new Error("flush error")),
+    });
+    runningEntries.set("issue-1", entry);
+
+    await handleWorkerFailure(ctx, makeIssue(), entry, new Error("crash"));
+
+    // Should have logged the flush failure warning
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "Error: flush error" }),
+      expect.stringContaining("failed to flush persistence"),
+    );
+    // And the fallback flush failure warning
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "Error: fallback flush failed" }),
+      expect.stringContaining("fallback attempt update also failed"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Status update fallback chain
+// ---------------------------------------------------------------------------
+
+describe("handleWorkerFailure - status update fallback", () => {
+  it("attempts fallback error code when main status update fails", async () => {
+    const updateAttempt = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("update failed")) // main update
+      .mockResolvedValueOnce(undefined); // fallback
+    const { ctx, runningEntries, warn } = makeCtx({ updateAttempt });
+    const entry = makeEntry();
+    runningEntries.set("issue-1", entry);
+
+    await handleWorkerFailure(ctx, makeIssue(), entry, new Error("crash"));
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "Error: update failed" }),
+      expect.stringContaining("failed to update attempt status"),
+    );
+    // Fallback should write errorCode: "update_failed"
+    expect(updateAttempt).toHaveBeenLastCalledWith("run-abc", { errorCode: "update_failed" });
+  });
+
+  it("logs warning when both main update and fallback fail", async () => {
+    const updateAttempt = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("update failed"))
+      .mockRejectedValueOnce(new Error("fallback failed"));
+    const { ctx, runningEntries, warn } = makeCtx({ updateAttempt });
+    const entry = makeEntry();
+    runningEntries.set("issue-1", entry);
+
+    await handleWorkerFailure(ctx, makeIssue(), entry, new Error("crash"));
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "Error: fallback failed" }),
+      expect.stringContaining("fallback error code update also failed"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Entry state after failure
+// ---------------------------------------------------------------------------
+
+describe("handleWorkerFailure - entry state", () => {
+  it("always removes running entry even when updates fail", async () => {
+    const updateAttempt = vi.fn().mockRejectedValue(new Error("all updates fail"));
+    const { ctx, runningEntries } = makeCtx({ updateAttempt });
+    const entry = makeEntry({
+      flushPersistence: vi.fn().mockRejectedValue(new Error("flush fails too")),
+    });
+    runningEntries.set("issue-1", entry);
+
+    await handleWorkerFailure(ctx, makeIssue(), entry, new Error("crash"));
+
+    expect(runningEntries.has("issue-1")).toBe(false);
+  });
+
+  it("always releases the issue claim even when updates fail", async () => {
+    const updateAttempt = vi.fn().mockRejectedValue(new Error("all updates fail"));
+    const { ctx, runningEntries, releaseIssueClaim } = makeCtx({ updateAttempt });
+    const entry = makeEntry({
+      flushPersistence: vi.fn().mockRejectedValue(new Error("flush fails")),
+    });
+    runningEntries.set("issue-1", entry);
+
+    await handleWorkerFailure(ctx, makeIssue(), entry, new Error("crash"));
+
+    expect(releaseIssueClaim).toHaveBeenCalledWith("issue-1");
+  });
+
+  it("always pushes the worker_failed event even when persistence fails", async () => {
+    const updateAttempt = vi.fn().mockRejectedValue(new Error("fail"));
+    const { ctx, runningEntries, pushEvent } = makeCtx({ updateAttempt });
+    const entry = makeEntry({
+      flushPersistence: vi.fn().mockRejectedValue(new Error("flush fail")),
+    });
+    runningEntries.set("issue-1", entry);
+
+    await handleWorkerFailure(ctx, makeIssue(), entry, new Error("crash"));
+
+    expect(pushEvent).toHaveBeenCalledWith(expect.objectContaining({ event: "worker_failed" }));
+  });
+});

--- a/tests/orchestrator/worker-launcher.test.ts
+++ b/tests/orchestrator/worker-launcher.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  canDispatchIssue,
+  hasAvailableStateSlot,
+  launchAvailableWorkers,
+} from "../../src/orchestrator/worker-launcher.js";
+import type { Issue, ServiceConfig } from "../../src/core/types.js";
+import type { RunningEntry } from "../../src/orchestrator/runtime-types.js";
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: "issue-1",
+    identifier: "MT-1",
+    title: "Test issue",
+    description: null,
+    priority: 1,
+    state: "In Progress",
+    branchName: null,
+    url: null,
+    labels: [],
+    blockedBy: [],
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<ServiceConfig["agent"]> = {}): ServiceConfig {
+  return {
+    tracker: {
+      kind: "linear",
+      apiKey: "key",
+      endpoint: "https://api.linear.app/graphql",
+      projectSlug: "MT",
+      activeStates: ["In Progress", "Todo"],
+      terminalStates: ["Done", "Canceled"],
+    },
+    agent: {
+      maxConcurrentAgents: 3,
+      maxConcurrentAgentsByState: {},
+      maxTurns: 10,
+      maxRetryBackoffMs: 300000,
+      maxContinuationAttempts: 5,
+      successState: null,
+      stallTimeoutMs: 1200000,
+      ...overrides,
+    },
+  } as unknown as ServiceConfig;
+}
+
+function makeEntry(overrides: Partial<RunningEntry> = {}): RunningEntry {
+  return {
+    runId: "run-abc",
+    issue: makeIssue(),
+    workspace: { path: "/tmp/ws/MT-1", workspaceKey: "ws-key", createdNow: true },
+    startedAtMs: Date.now() - 5000,
+    lastEventAtMs: Date.now(),
+    attempt: 1,
+    abortController: new AbortController(),
+    promise: Promise.resolve(),
+    cleanupOnExit: false,
+    status: "running",
+    sessionId: "sess-xyz",
+    tokenUsage: null,
+    modelSelection: { model: "gpt-4o", reasoningEffort: "high", source: "default" },
+    lastAgentMessageContent: null,
+    repoMatch: null,
+    queuePersistence: () => undefined,
+    flushPersistence: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as RunningEntry;
+}
+
+// ---------------------------------------------------------------------------
+// canDispatchIssue
+// ---------------------------------------------------------------------------
+
+describe("canDispatchIssue", () => {
+  it("returns true for an active-state issue that is not claimed or blocked", () => {
+    const config = makeConfig();
+    const issue = makeIssue({ state: "In Progress" });
+    expect(canDispatchIssue(issue, config, new Set())).toBe(true);
+  });
+
+  it("returns false when the issue state is not active", () => {
+    const config = makeConfig();
+    const issue = makeIssue({ state: "Backlog" });
+    expect(canDispatchIssue(issue, config, new Set())).toBe(false);
+  });
+
+  it("returns false when the issue is already claimed", () => {
+    const config = makeConfig();
+    const issue = makeIssue({ state: "In Progress" });
+    expect(canDispatchIssue(issue, config, new Set(["issue-1"]))).toBe(false);
+  });
+
+  it("returns false for a todo-state issue blocked by a non-terminal issue", () => {
+    const config = makeConfig();
+    const issue = makeIssue({
+      state: "Todo",
+      blockedBy: [{ id: "blk", identifier: "MT-0", state: "In Progress" }],
+    });
+    expect(canDispatchIssue(issue, config, new Set())).toBe(false);
+  });
+
+  it("returns true for a todo-state issue when all blockers are terminal", () => {
+    const config = makeConfig();
+    const issue = makeIssue({
+      state: "Todo",
+      blockedBy: [{ id: "blk", identifier: "MT-0", state: "Done" }],
+    });
+    expect(canDispatchIssue(issue, config, new Set())).toBe(true);
+  });
+
+  it("returns true for an active non-todo issue even with non-terminal blockers", () => {
+    const config = makeConfig();
+    const issue = makeIssue({
+      state: "In Progress",
+      blockedBy: [{ id: "blk", identifier: "MT-0", state: "In Progress" }],
+    });
+    // blocker check only applies to todo-state issues
+    expect(canDispatchIssue(issue, config, new Set())).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasAvailableStateSlot
+// ---------------------------------------------------------------------------
+
+describe("hasAvailableStateSlot", () => {
+  it("returns true when no per-state limit is configured", () => {
+    const config = makeConfig({ maxConcurrentAgentsByState: {} });
+    const issue = makeIssue({ state: "In Progress" });
+    expect(hasAvailableStateSlot(issue, config, new Map())).toBe(true);
+  });
+
+  it("returns true when running count is below the configured limit", () => {
+    const config = makeConfig({ maxConcurrentAgentsByState: { "in progress": 2 } });
+    const issue = makeIssue({ state: "In Progress" });
+
+    const runningEntries = new Map<string, RunningEntry>();
+    runningEntries.set("other-1", makeEntry({ issue: makeIssue({ id: "other-1", state: "In Progress" }) }));
+
+    expect(hasAvailableStateSlot(issue, config, runningEntries)).toBe(true);
+  });
+
+  it("returns false when running count reaches the configured limit", () => {
+    const config = makeConfig({ maxConcurrentAgentsByState: { "in progress": 1 } });
+    const issue = makeIssue({ state: "In Progress" });
+
+    const runningEntries = new Map<string, RunningEntry>();
+    runningEntries.set("other-1", makeEntry({ issue: makeIssue({ id: "other-1", state: "In Progress" }) }));
+
+    expect(hasAvailableStateSlot(issue, config, runningEntries)).toBe(false);
+  });
+
+  it("accounts for pending state counts on top of running entries", () => {
+    const config = makeConfig({ maxConcurrentAgentsByState: { "in progress": 2 } });
+    const issue = makeIssue({ state: "In Progress" });
+
+    const runningEntries = new Map<string, RunningEntry>();
+    runningEntries.set("other-1", makeEntry({ issue: makeIssue({ id: "other-1", state: "In Progress" }) }));
+
+    const pendingStateCounts = new Map([["in progress", 1]]);
+    // 1 running + 1 pending = 2 >= limit of 2
+    expect(hasAvailableStateSlot(issue, config, runningEntries, pendingStateCounts)).toBe(false);
+  });
+
+  it("allows dispatch when pending counts are absent", () => {
+    const config = makeConfig({ maxConcurrentAgentsByState: { "in progress": 2 } });
+    const issue = makeIssue({ state: "In Progress" });
+
+    const runningEntries = new Map<string, RunningEntry>();
+    runningEntries.set("other-1", makeEntry({ issue: makeIssue({ id: "other-1", state: "In Progress" }) }));
+
+    // pendingStateCounts undefined, only 1 running < 2 limit
+    expect(hasAvailableStateSlot(issue, config, runningEntries, undefined)).toBe(true);
+  });
+
+  it("normalizes state key for case-insensitive comparison", () => {
+    const config = makeConfig({ maxConcurrentAgentsByState: { "in progress": 1 } });
+    const issue = makeIssue({ state: "IN PROGRESS" });
+
+    const runningEntries = new Map<string, RunningEntry>();
+    runningEntries.set("other-1", makeEntry({ issue: makeIssue({ id: "other-1", state: "in progress" }) }));
+
+    expect(hasAvailableStateSlot(issue, config, runningEntries)).toBe(false);
+  });
+
+  it("does not count entries in different states toward the limit", () => {
+    const config = makeConfig({ maxConcurrentAgentsByState: { "in progress": 1 } });
+    const issue = makeIssue({ state: "In Progress" });
+
+    const runningEntries = new Map<string, RunningEntry>();
+    runningEntries.set("other-1", makeEntry({ issue: makeIssue({ id: "other-1", state: "Todo" }) }));
+
+    expect(hasAvailableStateSlot(issue, config, runningEntries)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// launchAvailableWorkers
+// ---------------------------------------------------------------------------
+
+describe("launchAvailableWorkers", () => {
+  function makeLaunchCtx(
+    overrides: {
+      issues?: Issue[];
+      maxConcurrentAgents?: number;
+      runningCount?: number;
+      canDispatch?: (issue: Issue) => boolean;
+      hasSlot?: (issue: Issue) => boolean;
+    } = {},
+  ) {
+    const {
+      issues = [makeIssue()],
+      maxConcurrentAgents = 3,
+      runningCount = 0,
+      canDispatch = () => true,
+      hasSlot = () => true,
+    } = overrides;
+
+    const runningEntries = new Map<string, RunningEntry>();
+    for (let idx = 0; idx < runningCount; idx++) {
+      const entry = makeEntry({ issue: makeIssue({ id: `running-${idx}` }) });
+      runningEntries.set(`running-${idx}`, entry);
+    }
+
+    const claimIssue = vi.fn();
+    const launchWorker = vi.fn().mockResolvedValue(undefined);
+    const fetchCandidateIssues = vi.fn().mockResolvedValue(issues);
+
+    const ctx = {
+      deps: { linearClient: { fetchCandidateIssues } },
+      getConfig: () => makeConfig({ maxConcurrentAgents }),
+      runningEntries,
+      claimIssue,
+      canDispatchIssue: canDispatch,
+      hasAvailableStateSlot: hasSlot,
+      launchWorker,
+    };
+
+    return { ctx, claimIssue, launchWorker, fetchCandidateIssues };
+  }
+
+  it("dispatches issues up to the available concurrency slots", async () => {
+    const issues = [
+      makeIssue({ id: "a", identifier: "MT-A", priority: 1 }),
+      makeIssue({ id: "b", identifier: "MT-B", priority: 2 }),
+      makeIssue({ id: "c", identifier: "MT-C", priority: 3 }),
+    ];
+    const { ctx, launchWorker, claimIssue } = makeLaunchCtx({
+      issues,
+      maxConcurrentAgents: 2,
+      runningCount: 0,
+    });
+
+    await launchAvailableWorkers(ctx);
+
+    expect(launchWorker).toHaveBeenCalledTimes(2);
+    expect(claimIssue).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not dispatch when already at concurrency limit", async () => {
+    const { ctx, launchWorker } = makeLaunchCtx({
+      maxConcurrentAgents: 2,
+      runningCount: 2,
+    });
+
+    await launchAvailableWorkers(ctx);
+
+    expect(launchWorker).not.toHaveBeenCalled();
+  });
+
+  it("skips issues that fail canDispatchIssue", async () => {
+    const issues = [makeIssue({ id: "skip", identifier: "MT-SKIP" }), makeIssue({ id: "ok", identifier: "MT-OK" })];
+    const { ctx, launchWorker } = makeLaunchCtx({
+      issues,
+      canDispatch: (issue: Issue) => issue.id !== "skip",
+    });
+
+    await launchAvailableWorkers(ctx);
+
+    expect(launchWorker).toHaveBeenCalledTimes(1);
+    expect(launchWorker).toHaveBeenCalledWith(expect.objectContaining({ id: "ok" }), null, { claimHeld: true });
+  });
+
+  it("skips issues that fail hasAvailableStateSlot", async () => {
+    const issues = [
+      makeIssue({ id: "a", identifier: "MT-A", state: "In Progress" }),
+      makeIssue({ id: "b", identifier: "MT-B", state: "In Progress" }),
+    ];
+
+    let callCount = 0;
+    const { ctx, launchWorker } = makeLaunchCtx({
+      issues,
+      hasSlot: () => {
+        callCount++;
+        // Only the first issue gets a slot
+        return callCount === 1;
+      },
+    });
+
+    await launchAvailableWorkers(ctx);
+
+    expect(launchWorker).toHaveBeenCalledTimes(1);
+  });
+
+  it("launches nothing when the candidate list is empty", async () => {
+    const { ctx, launchWorker } = makeLaunchCtx({ issues: [] });
+
+    await launchAvailableWorkers(ctx);
+
+    expect(launchWorker).not.toHaveBeenCalled();
+  });
+
+  it("passes claimHeld: true to each launched worker", async () => {
+    const issues = [makeIssue({ id: "a", identifier: "MT-A" })];
+    const { ctx, launchWorker } = makeLaunchCtx({ issues });
+
+    await launchAvailableWorkers(ctx);
+
+    expect(launchWorker).toHaveBeenCalledWith(expect.any(Object), null, { claimHeld: true });
+  });
+
+  it("claims each issue before launching it", async () => {
+    const issues = [makeIssue({ id: "a", identifier: "MT-A" })];
+    const { ctx, claimIssue, launchWorker } = makeLaunchCtx({ issues });
+
+    const callOrder: string[] = [];
+    claimIssue.mockImplementation(() => callOrder.push("claim"));
+    launchWorker.mockImplementation(async () => callOrder.push("launch"));
+
+    await launchAvailableWorkers(ctx);
+
+    expect(callOrder).toEqual(["claim", "launch"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 31 unit tests covering `canDispatchIssue`, `hasAvailableStateSlot`, `launchAvailableWorkers`, and `handleWorkerFailure` -- the two largest previously untested orchestrator modules.
- Tests cover active/inactive state dispatch, claimed issue filtering, todo-state blocker checks, per-state concurrency limits, concurrency slot exhaustion, flush-failure fallback chains, TokenRefreshError code propagation, and resilience guarantees (entry cleanup and claim release even when all persistence operations fail).

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors, 3 pre-existing warnings)
- [x] `npm run format:check` passes
- [x] `npm test` passes (903 tests, 31 new)
- [x] `npm run knip` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
