### PR TITLE
test(setup): add setup-status and workspace paths tests

### DIFF
--- a/tests/setup/setup-status.test.ts
+++ b/tests/setup/setup-status.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  hasCodexAuthFile,
+  hasLinearCredentials,
+  readProjectSlug,
+  hasRepoRoutes,
+} from "../../src/setup/setup-status.js";
+import { SecretsStore } from "../../src/secrets/store.js";
+import { createMockLogger } from "../helpers.js";
+
+/* ── fs mock (hoisted) ───────────────────────────────────────────── */
+
+const existsSyncMock = vi.hoisted(() => vi.fn<(filePath: string) => boolean>());
+
+vi.mock("node:fs", () => ({ existsSync: existsSyncMock }));
+
+/* ── SecretsStore helper ─────────────────────────────────────────── */
+
+function makeSecretsStore(): SecretsStore {
+  const store = new SecretsStore("/tmp/secrets-test", createMockLogger());
+  vi.spyOn(store, "get").mockReturnValue(null);
+  return store;
+}
+
+/* ── env snapshot ────────────────────────────────────────────────── */
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  existsSyncMock.mockReset();
+  existsSyncMock.mockReturnValue(false);
+  process.env = { ...originalEnv };
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.restoreAllMocks();
+});
+
+/* ── readOverlayString — flat-key vs nested-path resolution ─────── */
+
+describe("readOverlayString resolution (via hasCodexAuthFile)", () => {
+  it("resolves flat-key overlay (codex.auth.source_home)", () => {
+    existsSyncMock.mockReturnValue(true);
+
+    const overlay = { "codex.auth.source_home": "/custom/auth" };
+    expect(hasCodexAuthFile("/archive", overlay)).toBe(true);
+    expect(existsSyncMock).toHaveBeenCalledWith("/custom/auth/auth.json");
+  });
+
+  it("resolves nested-path overlay (codex → auth → source_home)", () => {
+    existsSyncMock.mockReturnValue(true);
+
+    const overlay = { codex: { auth: { source_home: "/nested/auth" } } };
+    expect(hasCodexAuthFile("/archive", overlay)).toBe(true);
+    expect(existsSyncMock).toHaveBeenCalledWith("/nested/auth/auth.json");
+  });
+
+  it("falls back to archive-based path when no overlay is set", () => {
+    existsSyncMock.mockReturnValue(false);
+
+    expect(hasCodexAuthFile("/archive", {})).toBe(false);
+    expect(existsSyncMock).toHaveBeenCalledWith("/archive/codex-auth/auth.json");
+  });
+
+  it("returns false when auth.mode is empty string", () => {
+    const overlay = { "codex.auth.mode": "" };
+    expect(hasCodexAuthFile("/archive", overlay)).toBe(false);
+  });
+
+  it("returns false when source_home is empty string", () => {
+    const overlay = { "codex.auth.source_home": "" };
+    expect(hasCodexAuthFile("/archive", overlay)).toBe(false);
+  });
+});
+
+/* ── prototype-pollution defense ─────────────────────────────────── */
+
+describe("prototype-pollution defense", () => {
+  it("does not resolve inherited properties from prototype chain", () => {
+    // readOverlayString uses Object.getOwnPropertyDescriptor, so inherited
+    // properties should NOT be resolved
+    const proto = { tracker: { project_slug: "inherited-slug" } };
+    const overlay = Object.create(proto) as Record<string, unknown>;
+    expect(readProjectSlug(overlay)).toBeUndefined();
+  });
+
+  it("does not resolve constructor from Object.prototype", () => {
+    const overlay: Record<string, unknown> = {};
+    expect(readProjectSlug(overlay)).toBeUndefined();
+  });
+
+  it("resolves own properties normally", () => {
+    const overlay: Record<string, unknown> = { tracker: { project_slug: "SAFE-SLUG" } };
+    expect(readProjectSlug(overlay)).toBe("SAFE-SLUG");
+  });
+});
+
+/* ── hasCodexAuthFile ────────────────────────────────────────────── */
+
+describe("hasCodexAuthFile", () => {
+  it("returns true when auth.json exists in the derived path", () => {
+    existsSyncMock.mockReturnValue(true);
+    expect(hasCodexAuthFile("/archive", {})).toBe(true);
+    expect(existsSyncMock).toHaveBeenCalledWith("/archive/codex-auth/auth.json");
+  });
+
+  it("returns false when auth.json does not exist", () => {
+    existsSyncMock.mockReturnValue(false);
+    expect(hasCodexAuthFile("/archive", {})).toBe(false);
+  });
+
+  it("prefers flat key over nested when both are present", () => {
+    existsSyncMock.mockReturnValue(true);
+    const overlay = {
+      "codex.auth.source_home": "/flat-wins",
+      codex: { auth: { source_home: "/nested-loses" } },
+    };
+    expect(hasCodexAuthFile("/archive", overlay)).toBe(true);
+    expect(existsSyncMock).toHaveBeenCalledWith("/flat-wins/auth.json");
+  });
+
+  it("falls through to default when flat value is not a string", () => {
+    existsSyncMock.mockReturnValue(true);
+    const overlay = { "codex.auth.source_home": 42 };
+    expect(hasCodexAuthFile("/archive", overlay as Record<string, unknown>)).toBe(true);
+    expect(existsSyncMock).toHaveBeenCalledWith("/archive/codex-auth/auth.json");
+  });
+});
+
+/* ── hasLinearCredentials ────────────────────────────────────────── */
+
+describe("hasLinearCredentials", () => {
+  it("returns true when secrets store has the key", () => {
+    const store = makeSecretsStore();
+    vi.mocked(store.get).mockReturnValue("lin_api_xxx");
+    expect(hasLinearCredentials(store)).toBe(true);
+  });
+
+  it("returns true when environment variable is set", () => {
+    const store = makeSecretsStore();
+    process.env.LINEAR_API_KEY = "env_key";
+    expect(hasLinearCredentials(store)).toBe(true);
+  });
+
+  it("returns false when neither store nor env has the key", () => {
+    const store = makeSecretsStore();
+    delete process.env.LINEAR_API_KEY;
+    expect(hasLinearCredentials(store)).toBe(false);
+  });
+
+  it("returns false when env variable is empty string", () => {
+    const store = makeSecretsStore();
+    process.env.LINEAR_API_KEY = "";
+    expect(hasLinearCredentials(store)).toBe(false);
+  });
+});
+
+/* ── readProjectSlug ─────────────────────────────────────────────── */
+
+describe("readProjectSlug", () => {
+  it("reads flat-key slug", () => {
+    expect(readProjectSlug({ "tracker.project_slug": "MY-PROJECT" })).toBe("MY-PROJECT");
+  });
+
+  it("reads nested-path slug", () => {
+    expect(readProjectSlug({ tracker: { project_slug: "NESTED-SLUG" } })).toBe("NESTED-SLUG");
+  });
+
+  it("returns undefined when slug is absent", () => {
+    expect(readProjectSlug({})).toBeUndefined();
+  });
+
+  it("returns undefined when slug is empty string", () => {
+    expect(readProjectSlug({ "tracker.project_slug": "" })).toBeUndefined();
+  });
+
+  it("returns undefined when nested value is non-string", () => {
+    expect(readProjectSlug({ tracker: { project_slug: 123 } })).toBeUndefined();
+  });
+});
+
+/* ── hasRepoRoutes ───────────────────────────────────────────────── */
+
+describe("hasRepoRoutes", () => {
+  it("returns true when repos is a non-empty array", () => {
+    expect(hasRepoRoutes({ repos: [{ url: "https://github.com/org/repo" }] })).toBe(true);
+  });
+
+  it("returns false when repos is an empty array", () => {
+    expect(hasRepoRoutes({ repos: [] })).toBe(false);
+  });
+
+  it("returns false when repos is not an array", () => {
+    expect(hasRepoRoutes({ repos: "not-an-array" })).toBe(false);
+  });
+
+  it("returns false when repos key is absent", () => {
+    expect(hasRepoRoutes({})).toBe(false);
+  });
+
+  it("returns false when repos is null", () => {
+    expect(hasRepoRoutes({ repos: null })).toBe(false);
+  });
+});

--- a/tests/workspace/paths.test.ts
+++ b/tests/workspace/paths.test.ts
@@ -1,0 +1,132 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildSafePath, isWithinRoot, sanitizeIdentifier, resolveWorkspacePath } from "../../src/workspace/paths.js";
+
+/* ── env snapshot ────────────────────────────────────────────────── */
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+/* ── buildSafePath (edge cases beyond safe-path.test.ts) ─────────── */
+
+describe("buildSafePath", () => {
+  it("preserves all six known safe directories", () => {
+    process.env.PATH = "/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin";
+    expect(buildSafePath()).toBe("/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin");
+  });
+
+  it("returns fallback when PATH is empty string", () => {
+    process.env.PATH = "";
+    expect(buildSafePath()).toBe("/usr/local/bin:/usr/bin:/bin");
+  });
+});
+
+/* ── isWithinRoot ────────────────────────────────────────────────── */
+
+describe("isWithinRoot", () => {
+  it("accepts a path directly inside the root", () => {
+    expect(isWithinRoot("/workspace", "/workspace/issue-1")).toBe(true);
+  });
+
+  it("accepts a deeply nested path inside the root", () => {
+    expect(isWithinRoot("/workspace", "/workspace/a/b/c")).toBe(true);
+  });
+
+  it("accepts the root path itself", () => {
+    expect(isWithinRoot("/workspace", "/workspace")).toBe(true);
+  });
+
+  it("rejects a path that escapes the root via ../", () => {
+    expect(isWithinRoot("/workspace", "/workspace/../etc/passwd")).toBe(false);
+  });
+
+  it("rejects a completely unrelated path", () => {
+    expect(isWithinRoot("/workspace", "/other/directory")).toBe(false);
+  });
+
+  it("rejects a sibling path with a similar prefix", () => {
+    expect(isWithinRoot("/workspace", "/workspace-extra/data")).toBe(false);
+  });
+
+  it("rejects a parent directory", () => {
+    expect(isWithinRoot("/workspace/sub", "/workspace")).toBe(false);
+  });
+
+  it("handles trailing slashes correctly", () => {
+    expect(isWithinRoot("/workspace/", "/workspace/file.txt")).toBe(true);
+  });
+});
+
+/* ── sanitizeIdentifier ──────────────────────────────────────────── */
+
+describe("sanitizeIdentifier", () => {
+  it("passes through a clean identifier unchanged", () => {
+    expect(sanitizeIdentifier("MT-42")).toBe("MT-42");
+  });
+
+  it("replaces spaces with underscores", () => {
+    expect(sanitizeIdentifier("my issue")).toBe("my_issue");
+  });
+
+  it("replaces slashes with underscores", () => {
+    expect(sanitizeIdentifier("org/repo#123")).toBe("org_repo_123");
+  });
+
+  it("preserves dots and hyphens", () => {
+    expect(sanitizeIdentifier("v1.2.3-rc1")).toBe("v1.2.3-rc1");
+  });
+
+  it("replaces special characters", () => {
+    expect(sanitizeIdentifier("issue@#$%^&*()")).toBe("issue_________");
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeIdentifier("")).toBe("");
+  });
+
+  it("replaces unicode characters", () => {
+    expect(sanitizeIdentifier("issue-\u00e9\u00e8")).toBe("issue-__");
+  });
+
+  it("handles path traversal characters", () => {
+    expect(sanitizeIdentifier("../../etc/passwd")).toBe(".._.._etc_passwd");
+  });
+});
+
+/* ── resolveWorkspacePath ────────────────────────────────────────── */
+
+describe("resolveWorkspacePath", () => {
+  it("returns a sanitized key and resolved path for a clean identifier", () => {
+    const result = resolveWorkspacePath("/workspaces", "MT-42");
+    expect(result.workspaceKey).toBe("MT-42");
+    expect(result.workspacePath).toBe(path.resolve("/workspaces", "MT-42"));
+  });
+
+  it("sanitizes the identifier before resolving", () => {
+    const result = resolveWorkspacePath("/workspaces", "org/repo#99");
+    expect(result.workspaceKey).toBe("org_repo_99");
+    expect(result.workspacePath).toBe(path.resolve("/workspaces", "org_repo_99"));
+  });
+
+  it("handles identifiers with dots and hyphens", () => {
+    const result = resolveWorkspacePath("/workspaces", "project-1.0");
+    expect(result.workspaceKey).toBe("project-1.0");
+    expect(result.workspacePath).toBe(path.resolve("/workspaces", "project-1.0"));
+  });
+
+  it("throws on identifiers that produce a path starting with '..'", () => {
+    // "../../etc" sanitizes to ".._.._etc" which starts with ".." and
+    // fails the isWithinRoot check, triggering the escape guard
+    expect(() => resolveWorkspacePath("/workspaces", "../../etc")).toThrow("workspace path escaped root");
+  });
+
+  it("does not throw for safe identifiers", () => {
+    const result = resolveWorkspacePath("/workspaces", "safe-identifier");
+    expect(result.workspaceKey).toBe("safe-identifier");
+    expect(isWithinRoot("/workspaces", result.workspacePath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add unit tests for `src/setup/setup-status.ts` covering `hasCodexAuthFile`, `hasLinearCredentials`, `readProjectSlug`, and `hasRepoRoutes`
- Add unit tests for `src/workspace/paths.ts` covering `isWithinRoot`, `sanitizeIdentifier`, and `resolveWorkspacePath` (plus edge cases for `buildSafePath` not covered by `safe-path.test.ts`)
- Tests validate overlay flat-key vs nested-path resolution, prototype-pollution defense via `Object.getOwnPropertyDescriptor`, path traversal prevention, and identifier sanitization

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors, pre-existing warnings only)
- [x] `npm run format:check` passes
- [x] `npm test` passes (49 new tests across 2 files; 921 total passing)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
