### PR TITLE
test(frontend): add format, single-flight, and store utility tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:e2e:smoke": "playwright test --project=smoke",
     "test:e2e:visual": "playwright test --project=visual",
     "test:e2e:update": "playwright test --project=visual --update-snapshots",
+    "test:frontend": "vitest run --config vitest.frontend.config.ts",
     "test:e2e:legacy": "vitest run tests/integration/e2e-smoke.test.ts",
     "dev": "tsx watch src/cli/index.ts",
     "dev:frontend": "vite --config frontend/vite.config.ts",

--- a/tests/frontend/format.test.ts
+++ b/tests/frontend/format.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  computeDurationSeconds,
+  formatBytes,
+  formatCompactNumber,
+  formatCountdown,
+  formatDuration,
+  formatRateLimitHeadroom,
+  formatRelativeTime,
+  formatTimestamp,
+  formatTokenUsage,
+} from "../../frontend/src/utils/format";
+
+describe("formatCompactNumber", () => {
+  it("returns dash for null, undefined, and NaN", () => {
+    expect(formatCompactNumber(null)).toBe("—");
+    expect(formatCompactNumber(undefined)).toBe("—");
+    expect(formatCompactNumber(NaN)).toBe("—");
+  });
+
+  it("formats zero as standard notation", () => {
+    expect(formatCompactNumber(0)).toBe("0");
+  });
+
+  it("formats numbers below 1000 without compact notation", () => {
+    expect(formatCompactNumber(1)).toBe("1");
+    expect(formatCompactNumber(999)).toBe("999");
+    expect(formatCompactNumber(42)).toBe("42");
+  });
+
+  it("formats numbers at or above 1000 with compact notation", () => {
+    expect(formatCompactNumber(1000)).toBe("1K");
+    expect(formatCompactNumber(1500)).toBe("1.5K");
+    expect(formatCompactNumber(10_000)).toBe("10K");
+    expect(formatCompactNumber(1_000_000)).toBe("1M");
+  });
+
+  it("handles negative numbers below 1000 absolute value", () => {
+    expect(formatCompactNumber(-42)).toBe("-42");
+  });
+
+  it("formats negative numbers above 1000 with standard notation (no compact)", () => {
+    // The implementation checks `value >= 1000` — negative values fail that
+    // check, so they use "standard" notation with locale grouping.
+    const result = formatCompactNumber(-1500);
+    expect(result).toMatch(/-1[,.]?500/);
+  });
+
+  it("handles very large numbers", () => {
+    const result = formatCompactNumber(1_000_000_000);
+    expect(result).toBe("1B");
+  });
+});
+
+describe("formatTokenUsage", () => {
+  it("returns dash for null, undefined, and zero", () => {
+    expect(formatTokenUsage(null)).toBe("—");
+    expect(formatTokenUsage(undefined)).toBe("—");
+    expect(formatTokenUsage(0)).toBe("—");
+  });
+
+  it("formats token counts with suffix", () => {
+    expect(formatTokenUsage(500)).toBe("500 tokens");
+    expect(formatTokenUsage(2500)).toBe("2.5k tokens");
+  });
+});
+
+describe("formatDuration", () => {
+  it("returns dash for null, undefined, and NaN", () => {
+    expect(formatDuration(null)).toBe("—");
+    expect(formatDuration(undefined)).toBe("—");
+    expect(formatDuration(NaN)).toBe("—");
+  });
+
+  it("formats zero seconds", () => {
+    expect(formatDuration(0)).toBe("00:00:00");
+  });
+
+  it("formats seconds under a minute", () => {
+    expect(formatDuration(5)).toBe("00:00:05");
+    expect(formatDuration(59)).toBe("00:00:59");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatDuration(90)).toBe("00:01:30");
+    expect(formatDuration(3599)).toBe("00:59:59");
+  });
+
+  it("formats hours, minutes, and seconds", () => {
+    expect(formatDuration(3600)).toBe("01:00:00");
+    expect(formatDuration(3661)).toBe("01:01:01");
+    expect(formatDuration(86400)).toBe("24:00:00");
+  });
+
+  it("clamps negative values to zero", () => {
+    expect(formatDuration(-10)).toBe("00:00:00");
+  });
+
+  it("rounds fractional seconds", () => {
+    expect(formatDuration(1.7)).toBe("00:00:02");
+    expect(formatDuration(0.4)).toBe("00:00:00");
+  });
+});
+
+describe("formatRelativeTime", () => {
+  it("returns dash for null, undefined, and empty string", () => {
+    expect(formatRelativeTime(null)).toBe("—");
+    expect(formatRelativeTime(undefined)).toBe("—");
+    expect(formatRelativeTime("")).toBe("—");
+  });
+
+  it("returns dash for invalid date strings", () => {
+    expect(formatRelativeTime("not-a-date")).toBe("—");
+  });
+
+  it('returns "just now" for timestamps within 5 seconds of now', () => {
+    const now = new Date();
+    expect(formatRelativeTime(now.toISOString())).toBe("just now");
+    expect(formatRelativeTime(new Date(now.getTime() - 3000).toISOString())).toBe("just now");
+  });
+
+  it("returns a relative time string for older timestamps", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-26T12:00:00Z"));
+
+    const tenSecondsAgo = "2026-03-26T11:59:50Z";
+    expect(formatRelativeTime(tenSecondsAgo)).toBe("10 seconds ago");
+
+    const twoMinutesAgo = "2026-03-26T11:58:00Z";
+    expect(formatRelativeTime(twoMinutesAgo)).toBe("2 minutes ago");
+
+    const oneHourAgo = "2026-03-26T11:00:00Z";
+    expect(formatRelativeTime(oneHourAgo)).toBe("1 hour ago");
+
+    vi.useRealTimers();
+  });
+
+  it("handles future timestamps", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-26T12:00:00Z"));
+
+    const tenSecondsFromNow = "2026-03-26T12:00:10Z";
+    expect(formatRelativeTime(tenSecondsFromNow)).toBe("in 10 seconds");
+
+    vi.useRealTimers();
+  });
+});
+
+describe("formatCountdown", () => {
+  const now = new Date("2026-03-26T12:00:00Z").getTime();
+
+  it("returns dash for null, undefined, and empty string", () => {
+    expect(formatCountdown(null, now)).toBe("—");
+    expect(formatCountdown(undefined, now)).toBe("—");
+    expect(formatCountdown("", now)).toBe("—");
+  });
+
+  it("returns dash for invalid dates", () => {
+    expect(formatCountdown("garbage", now)).toBe("—");
+  });
+
+  it('returns "now" when the target is within 1 second', () => {
+    expect(formatCountdown("2026-03-26T12:00:00Z", now)).toBe("now");
+  });
+
+  it("formats future countdowns with 'in' prefix", () => {
+    expect(formatCountdown("2026-03-26T12:00:30Z", now)).toBe("in 30s");
+    expect(formatCountdown("2026-03-26T12:05:00Z", now)).toBe("in 5m 0s");
+    expect(formatCountdown("2026-03-26T13:30:45Z", now)).toBe("in 1h 30m 45s");
+  });
+
+  it("formats past countdowns with 'ago' suffix", () => {
+    expect(formatCountdown("2026-03-26T11:59:30Z", now)).toBe("30s ago");
+    expect(formatCountdown("2026-03-26T11:55:00Z", now)).toBe("5m 0s ago");
+  });
+});
+
+describe("formatTimestamp", () => {
+  it("returns dash for null, undefined, and invalid dates", () => {
+    expect(formatTimestamp(null)).toBe("—");
+    expect(formatTimestamp(undefined)).toBe("—");
+    expect(formatTimestamp("bad-date")).toBe("—");
+  });
+
+  it("formats a valid ISO timestamp", () => {
+    const result = formatTimestamp("2026-03-26T12:00:00Z");
+    expect(result).toBeTruthy();
+    expect(result).not.toBe("—");
+    expect(result).toMatch(/Mar/);
+  });
+});
+
+describe("formatRateLimitHeadroom", () => {
+  it('returns "N/A" for null and non-object values', () => {
+    expect(formatRateLimitHeadroom(null)).toBe("N/A");
+  });
+
+  it('returns "N/A" when limit is zero or missing', () => {
+    expect(formatRateLimitHeadroom({})).toBe("N/A");
+    expect(formatRateLimitHeadroom({ limit: 0, remaining: 50 })).toBe("N/A");
+  });
+
+  it("calculates headroom percentage from limit and remaining", () => {
+    expect(formatRateLimitHeadroom({ limit: 100, remaining: 75 })).toBe("75.0%");
+    expect(formatRateLimitHeadroom({ limit: 1000, remaining: 500 })).toBe("50.0%");
+  });
+
+  it("uses 'total' field as fallback for limit", () => {
+    expect(formatRateLimitHeadroom({ total: 200, remaining: 100 })).toBe("50.0%");
+  });
+
+  it("handles full and empty headroom", () => {
+    expect(formatRateLimitHeadroom({ limit: 100, remaining: 100 })).toBe("100.0%");
+    expect(formatRateLimitHeadroom({ limit: 100, remaining: 0 })).toBe("0.0%");
+  });
+});
+
+describe("computeDurationSeconds", () => {
+  it("returns null when start is null, undefined, or invalid", () => {
+    expect(computeDurationSeconds(null)).toBeNull();
+    expect(computeDurationSeconds(undefined)).toBeNull();
+    expect(computeDurationSeconds("bad")).toBeNull();
+  });
+
+  it("computes seconds between start and end", () => {
+    const result = computeDurationSeconds("2026-03-26T12:00:00Z", "2026-03-26T12:05:00Z");
+    expect(result).toBe(300);
+  });
+
+  it("falls back to Date.now() when end is missing", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-26T12:01:00Z"));
+
+    const result = computeDurationSeconds("2026-03-26T12:00:00Z");
+    expect(result).toBe(60);
+
+    vi.useRealTimers();
+  });
+
+  it("clamps negative duration to zero", () => {
+    const result = computeDurationSeconds("2026-03-26T12:05:00Z", "2026-03-26T12:00:00Z");
+    expect(result).toBe(0);
+  });
+});
+
+describe("formatBytes", () => {
+  it("returns dash for null, undefined, and negative values", () => {
+    expect(formatBytes(null)).toBe("—");
+    expect(formatBytes(undefined)).toBe("—");
+    expect(formatBytes(-1)).toBe("—");
+  });
+
+  it('returns "0 B" for zero', () => {
+    expect(formatBytes(0)).toBe("0 B");
+  });
+
+  it("formats bytes without conversion", () => {
+    expect(formatBytes(100)).toBe("100 B");
+    expect(formatBytes(1023)).toBe("1023 B");
+  });
+
+  it("formats kilobytes", () => {
+    // Exact unit boundaries use .toFixed(1) because value < 10 && i > 0
+    expect(formatBytes(1024)).toBe("1.0 KB");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(formatBytes(10_240)).toBe("10 KB");
+    expect(formatBytes(15_360)).toBe("15 KB");
+  });
+
+  it("formats megabytes", () => {
+    expect(formatBytes(1_048_576)).toBe("1.0 MB");
+    expect(formatBytes(5_242_880)).toBe("5.0 MB");
+    expect(formatBytes(9_961_472)).toBe("9.5 MB");
+    expect(formatBytes(10_485_760)).toBe("10 MB");
+  });
+
+  it("formats gigabytes", () => {
+    expect(formatBytes(1_073_741_824)).toBe("1.0 GB");
+  });
+
+  it("formats terabytes", () => {
+    expect(formatBytes(1_099_511_627_776)).toBe("1.0 TB");
+  });
+});

--- a/tests/frontend/single-flight.test.ts
+++ b/tests/frontend/single-flight.test.ts
@@ -4,10 +4,12 @@ import { createSingleFlight } from "../../frontend/src/utils/single-flight";
 
 function createDeferred<T>() {
   let resolve = (_value: T): void => undefined;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject = (_error: Error): void => undefined;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 describe("createSingleFlight", () => {
@@ -34,5 +36,57 @@ describe("createSingleFlight", () => {
     await expect(singleFlight()).resolves.toBe("first");
     await expect(singleFlight()).resolves.toBe("second");
     expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears in-flight state after rejection so subsequent calls succeed", async () => {
+    const deferred = createDeferred<string>();
+    const run = vi
+      .fn()
+      .mockImplementationOnce(async () => deferred.promise)
+      .mockResolvedValueOnce("recovered");
+
+    const singleFlight = createSingleFlight(run);
+
+    const failingCall = singleFlight();
+    deferred.reject(new Error("network down"));
+    await expect(failingCall).rejects.toThrow("network down");
+
+    await expect(singleFlight()).resolves.toBe("recovered");
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces many concurrent callers into one execution", async () => {
+    const deferred = createDeferred<number>();
+    const run = vi.fn(async () => deferred.promise);
+    const singleFlight = createSingleFlight(run);
+
+    const calls = Array.from({ length: 10 }, () => singleFlight());
+    expect(run).toHaveBeenCalledTimes(1);
+
+    // All 10 promises are the same reference
+    for (const call of calls) {
+      expect(call).toBe(calls[0]);
+    }
+
+    deferred.resolve(42);
+    const results = await Promise.all(calls);
+    expect(results).toEqual(Array.from({ length: 10 }, () => 42));
+  });
+
+  it("allows interleaved success-failure-success cycles", async () => {
+    let callCount = 0;
+    const run = vi.fn(async () => {
+      callCount += 1;
+      if (callCount === 2) {
+        throw new Error("transient");
+      }
+      return `ok-${callCount}`;
+    });
+    const singleFlight = createSingleFlight(run);
+
+    await expect(singleFlight()).resolves.toBe("ok-1");
+    await expect(singleFlight()).rejects.toThrow("transient");
+    await expect(singleFlight()).resolves.toBe("ok-3");
+    expect(run).toHaveBeenCalledTimes(3);
   });
 });

--- a/tests/frontend/store.test.ts
+++ b/tests/frontend/store.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { RuntimeSnapshot } from "../../frontend/src/types";
 import { APP_STATE_HEARTBEAT_EVENT, APP_STATE_UPDATE_EVENT, StateStore } from "../../frontend/src/state/store";
 import { createSnapshot, installDomHarness } from "./helpers";
 
@@ -9,6 +10,28 @@ describe("StateStore", () => {
   afterEach(() => {
     restoreDom?.();
     restoreDom = null;
+  });
+
+  it("starts with null snapshot and zero staleCount", () => {
+    const dom = installDomHarness();
+    restoreDom = () => dom.restore();
+    const store = new StateStore();
+
+    expect(store.getState().snapshot).toBeNull();
+    expect(store.getState().staleCount).toBe(0);
+  });
+
+  it("emits update on first snapshot merge", () => {
+    const dom = installDomHarness();
+    restoreDom = () => dom.restore();
+    const store = new StateStore();
+    const onUpdate = vi.fn();
+
+    window.addEventListener(APP_STATE_UPDATE_EVENT, onUpdate);
+    store.mergeSnapshot(createSnapshot("2026-03-20T00:00:00.000Z"));
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(store.getState().snapshot).not.toBeNull();
   });
 
   it("does not emit an update when resetStale runs on an already-fresh store", () => {
@@ -64,5 +87,116 @@ describe("StateStore", () => {
     expect(onUpdate).toHaveBeenCalledTimes(1);
     expect(onHeartbeat).not.toHaveBeenCalled();
     expect(store.getState().staleCount).toBe(0);
+  });
+
+  it("emits update when material snapshot data changes", () => {
+    const dom = installDomHarness();
+    restoreDom = () => dom.restore();
+    const store = new StateStore();
+    const onUpdate = vi.fn();
+
+    window.addEventListener(APP_STATE_UPDATE_EVENT, onUpdate);
+
+    store.mergeSnapshot(createSnapshot("2026-03-20T00:00:00.000Z"));
+    onUpdate.mockReset();
+
+    const changed: RuntimeSnapshot = {
+      ...createSnapshot("2026-03-20T00:00:05.000Z"),
+      counts: { running: 3, retrying: 1 },
+    };
+    store.mergeSnapshot(changed);
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(store.getState().snapshot?.counts.running).toBe(3);
+  });
+
+  it("incrementStale raises the counter and emits update", () => {
+    const dom = installDomHarness();
+    restoreDom = () => dom.restore();
+    const store = new StateStore();
+    const onUpdate = vi.fn();
+
+    window.addEventListener(APP_STATE_UPDATE_EVENT, onUpdate);
+
+    store.incrementStale();
+    expect(store.getState().staleCount).toBe(1);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+
+    store.incrementStale();
+    expect(store.getState().staleCount).toBe(2);
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it("resetStale emits update only when staleCount was non-zero", () => {
+    const dom = installDomHarness();
+    restoreDom = () => dom.restore();
+    const store = new StateStore();
+    const onUpdate = vi.fn();
+
+    window.addEventListener(APP_STATE_UPDATE_EVENT, onUpdate);
+
+    store.incrementStale();
+    store.incrementStale();
+    onUpdate.mockReset();
+
+    store.resetStale();
+    expect(store.getState().staleCount).toBe(0);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+
+    onUpdate.mockReset();
+    store.resetStale();
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("detects array changes in snapshot data", () => {
+    const dom = installDomHarness();
+    restoreDom = () => dom.restore();
+    const store = new StateStore();
+    const onUpdate = vi.fn();
+
+    window.addEventListener(APP_STATE_UPDATE_EVENT, onUpdate);
+
+    store.mergeSnapshot(createSnapshot("2026-03-20T00:00:00.000Z"));
+    onUpdate.mockReset();
+
+    const withEvent: RuntimeSnapshot = {
+      ...createSnapshot("2026-03-20T00:00:05.000Z"),
+      recent_events: [
+        {
+          at: "2026-03-20T00:00:04.000Z",
+          issue_id: "i1",
+          issue_identifier: "TEST-1",
+          session_id: null,
+          event: "started",
+          message: "Started",
+          content: null,
+        },
+      ],
+    };
+    store.mergeSnapshot(withEvent);
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(store.getState().snapshot?.recent_events).toHaveLength(1);
+  });
+
+  it("does not emit when re-merging an identical snapshot", () => {
+    const dom = installDomHarness();
+    restoreDom = () => dom.restore();
+    const store = new StateStore();
+    const onUpdate = vi.fn();
+    const onHeartbeat = vi.fn();
+
+    window.addEventListener(APP_STATE_UPDATE_EVENT, onUpdate);
+    window.addEventListener(APP_STATE_HEARTBEAT_EVENT, onHeartbeat);
+
+    const snapshot = createSnapshot("2026-03-20T00:00:00.000Z");
+    store.mergeSnapshot(snapshot);
+    onUpdate.mockReset();
+    onHeartbeat.mockReset();
+
+    store.mergeSnapshot(createSnapshot("2026-03-20T00:00:00.000Z"));
+
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(onHeartbeat).not.toHaveBeenCalled();
   });
 });

--- a/vitest.frontend.config.ts
+++ b/vitest.frontend.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/frontend/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary
- Create `vitest.frontend.config.ts` dedicated config targeting `tests/frontend/**/*.test.ts` and add `test:frontend` npm script
- Add `tests/frontend/format.test.ts` with comprehensive tests for all format utilities: `formatCompactNumber`, `formatTokenUsage`, `formatDuration`, `formatRelativeTime`, `formatCountdown`, `formatTimestamp`, `formatRateLimitHeadroom`, `computeDurationSeconds`, and `formatBytes` — covering null/undefined/NaN guards, edge cases, and boundary values
- Expand `tests/frontend/single-flight.test.ts` with rejection recovery, many-caller coalescing, and interleaved success/failure cycle tests
- Expand `tests/frontend/store.test.ts` with initial state, first merge, material data changes, incrementStale/resetStale behaviors, array change detection, and identical-snapshot no-op tests

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm run format:check` passes
- [x] `npm test` passes (926 tests, 103 files)
- [x] `npm run test:frontend` passes (106 tests, 16 files)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
