### PR TITLE
test(agent): add codex-request-handler and json-rpc-connection tests

### DIFF
--- a/tests/agent/codex-request-handler.test.ts
+++ b/tests/agent/codex-request-handler.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { handleCodexRequest } from "../../src/agent/codex-request-handler.js";
+import type { JsonRpcRequest } from "../../src/codex/protocol.js";
+import type { GithubApiToolClient } from "../../src/git/github-api-tool.js";
+import type { LinearClient } from "../../src/linear/client.js";
+
+vi.mock("../../src/linear/graphql-tool.js", () => ({
+  handleLinearGraphqlToolCall: vi.fn().mockResolvedValue({ success: true, contentItems: [] }),
+}));
+
+vi.mock("../../src/git/github-api-tool.js", () => ({
+  handleGithubApiToolCall: vi.fn().mockResolvedValue({ success: true, contentItems: [] }),
+}));
+
+const { handleLinearGraphqlToolCall } = await import("../../src/linear/graphql-tool.js");
+const { handleGithubApiToolCall } = await import("../../src/git/github-api-tool.js");
+
+function makeRequest(method: string, params?: unknown): JsonRpcRequest {
+  return { jsonrpc: "2.0", id: 1, method, params };
+}
+
+function mockLinearClient(): LinearClient {
+  return {} as unknown as LinearClient;
+}
+
+function mockGithubClient(): GithubApiToolClient {
+  return {
+    addPrComment: vi.fn().mockResolvedValue({ id: 1 }),
+    getPrStatus: vi.fn().mockResolvedValue({ state: "open" }),
+  };
+}
+
+describe("handleCodexRequest", () => {
+  describe("approval auto-accept", () => {
+    it("accepts commandExecution approval for session", async () => {
+      const result = await handleCodexRequest(makeRequest("item/commandExecution/requestApproval"), mockLinearClient());
+      expect(result.fatalFailure).toBeNull();
+      expect(result.response).toEqual({ decision: "acceptForSession" });
+    });
+
+    it("accepts fileChange approval for session", async () => {
+      const result = await handleCodexRequest(makeRequest("item/fileChange/requestApproval"), mockLinearClient());
+      expect(result.fatalFailure).toBeNull();
+      expect(result.response).toEqual({ decision: "acceptForSession" });
+    });
+
+    it("echoes back permissionProfile for permissions approval", async () => {
+      const params = { permissionProfile: "full-auto" };
+      const result = await handleCodexRequest(
+        makeRequest("item/permissions/requestApproval", params),
+        mockLinearClient(),
+      );
+      expect(result.fatalFailure).toBeNull();
+      expect(result.response).toEqual({ permissions: "full-auto", scope: "session" });
+    });
+
+    it("falls back to permissions field when permissionProfile is absent", async () => {
+      const params = { permissions: { read: true, write: true } };
+      const result = await handleCodexRequest(
+        makeRequest("item/permissions/requestApproval", params),
+        mockLinearClient(),
+      );
+      expect(result.fatalFailure).toBeNull();
+      expect(result.response).toEqual({
+        permissions: { read: true, write: true },
+        scope: "session",
+      });
+    });
+
+    it("returns null permissions when neither field is present", async () => {
+      const result = await handleCodexRequest(makeRequest("item/permissions/requestApproval", {}), mockLinearClient());
+      expect(result.response).toEqual({ permissions: null, scope: "session" });
+    });
+
+    it("handles non-object params gracefully for permissions approval", async () => {
+      const result = await handleCodexRequest(
+        makeRequest("item/permissions/requestApproval", "not-an-object"),
+        mockLinearClient(),
+      );
+      expect(result.fatalFailure).toBeNull();
+      expect(result.response).toEqual({ permissions: null, scope: "session" });
+    });
+  });
+
+  describe("tool dispatch — linear_graphql", () => {
+    it("dispatches linear_graphql call via name param", async () => {
+      const client = mockLinearClient();
+      const params = { name: "linear_graphql", arguments: { query: "{ viewer { id } }" } };
+      const result = await handleCodexRequest(makeRequest("item/tool/call", params), client);
+
+      expect(result.fatalFailure).toBeNull();
+      expect(result.response).toBeDefined();
+      expect(handleLinearGraphqlToolCall).toHaveBeenCalledWith(client, { query: "{ viewer { id } }" });
+    });
+
+    it("dispatches linear_graphql call via toolName param", async () => {
+      const client = mockLinearClient();
+      const params = { toolName: "linear_graphql", args: "{ viewer { id } }" };
+      const result = await handleCodexRequest(makeRequest("item/tool/call", params), client);
+
+      expect(result.fatalFailure).toBeNull();
+      expect(handleLinearGraphqlToolCall).toHaveBeenCalledWith(client, "{ viewer { id } }");
+    });
+  });
+
+  describe("tool dispatch — github_api", () => {
+    it("dispatches github_api call when client is provided", async () => {
+      const ghClient = mockGithubClient();
+      const toolArgs = { action: "get_pr_status", owner: "org", repo: "repo", pullNumber: 1 };
+      const params = { name: "github_api", arguments: toolArgs };
+      const result = await handleCodexRequest(makeRequest("item/tool/call", params), mockLinearClient(), ghClient);
+
+      expect(result.fatalFailure).toBeNull();
+      expect(handleGithubApiToolCall).toHaveBeenCalledWith(ghClient, toolArgs);
+    });
+
+    it("returns tool error when github_api client is not configured", async () => {
+      const params = {
+        name: "github_api",
+        arguments: { action: "get_pr_status", owner: "org", repo: "repo", pullNumber: 1 },
+      };
+      const result = await handleCodexRequest(makeRequest("item/tool/call", params), mockLinearClient());
+
+      expect(result.fatalFailure).toBeNull();
+      const response = result.response as { success: boolean; contentItems: { text: string }[] };
+      expect(response.success).toBe(false);
+      expect(response.contentItems[0].text).toContain("not configured");
+    });
+  });
+
+  describe("tool dispatch — unsupported tool", () => {
+    it("returns tool error for unknown tool name", async () => {
+      const params = { name: "unknown_tool", arguments: {} };
+      const result = await handleCodexRequest(makeRequest("item/tool/call", params), mockLinearClient());
+
+      expect(result.fatalFailure).toBeNull();
+      const response = result.response as { success: boolean; contentItems: { text: string }[] };
+      expect(response.success).toBe(false);
+      expect(response.contentItems[0].text).toContain("unsupported dynamic tool");
+    });
+
+    it("reports 'unknown' when tool name is missing entirely", async () => {
+      const result = await handleCodexRequest(makeRequest("item/tool/call", {}), mockLinearClient());
+
+      const response = result.response as { success: boolean; contentItems: { text: string }[] };
+      expect(response.success).toBe(false);
+      expect(response.contentItems[0].text).toContain("unknown");
+    });
+  });
+
+  describe("fatal failure classification", () => {
+    it("marks user input request as turn_input_required", async () => {
+      const result = await handleCodexRequest(makeRequest("item/tool/requestUserInput"), mockLinearClient());
+      expect(result.fatalFailure).toEqual({
+        code: "turn_input_required",
+        message: expect.stringContaining("interactive user input"),
+      });
+      expect(result.response).toBeUndefined();
+    });
+
+    it("marks MCP elicitation as startup_failed", async () => {
+      const result = await handleCodexRequest(makeRequest("mcpServer/elicitation/request"), mockLinearClient());
+      expect(result.fatalFailure).toEqual({
+        code: "startup_failed",
+        message: expect.stringContaining("MCP server"),
+      });
+    });
+
+    it("marks chatgpt token refresh as startup_failed", async () => {
+      const result = await handleCodexRequest(makeRequest("account/chatgptAuthTokens/refresh"), mockLinearClient());
+      expect(result.fatalFailure).toEqual({
+        code: "startup_failed",
+        message: expect.stringContaining("unsupported interactive request"),
+      });
+    });
+
+    it("marks applyPatchApproval as startup_failed", async () => {
+      const result = await handleCodexRequest(makeRequest("applyPatchApproval"), mockLinearClient());
+      expect(result.fatalFailure?.code).toBe("startup_failed");
+    });
+
+    it("marks execCommandApproval as startup_failed", async () => {
+      const result = await handleCodexRequest(makeRequest("execCommandApproval"), mockLinearClient());
+      expect(result.fatalFailure?.code).toBe("startup_failed");
+    });
+  });
+
+  describe("unsupported method fallback", () => {
+    it("returns startup_failed for completely unknown methods", async () => {
+      const result = await handleCodexRequest(makeRequest("some/totally/unknown/method"), mockLinearClient());
+      expect(result.fatalFailure).toEqual({
+        code: "startup_failed",
+        message: expect.stringContaining("unsupported codex request method"),
+      });
+    });
+
+    it("includes the unknown method name in the error message", async () => {
+      const result = await handleCodexRequest(makeRequest("custom/method"), mockLinearClient());
+      expect(result.fatalFailure?.message).toContain("custom/method");
+    });
+  });
+});

--- a/tests/agent/json-rpc-connection.test.ts
+++ b/tests/agent/json-rpc-connection.test.ts
@@ -1,0 +1,430 @@
+import { EventEmitter } from "node:events";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { JsonRpcConnection, JsonRpcTimeoutError } from "../../src/agent/json-rpc-connection.js";
+import type { JsonRpcRequest } from "../../src/codex/protocol.js";
+import { createMockLogger } from "../helpers.js";
+
+/**
+ * Creates a mock ChildProcessWithoutNullStreams using EventEmitter-based streams.
+ * stdin captures writes; stdout/stderr emit data events.
+ */
+function makeMockChild() {
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  const stdin = Object.assign(new EventEmitter(), {
+    write: vi.fn(),
+  });
+  const child = Object.assign(new EventEmitter(), {
+    stdout,
+    stderr,
+    stdin,
+    kill: vi.fn(),
+    pid: 12345,
+  });
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    child: child as any,
+    stdout,
+    stderr,
+    stdin,
+    sendLine(json: unknown): void {
+      stdout.emit("data", Buffer.from(JSON.stringify(json) + "\n"));
+    },
+    sendRaw(text: string): void {
+      stdout.emit("data", Buffer.from(text));
+    },
+    exit(): void {
+      child.emit("exit");
+    },
+    kill: child.kill,
+  };
+}
+
+/** Parse the last JSON-RPC message written to the mock child's stdin. */
+function lastSentMessage(mock: ReturnType<typeof makeMockChild>): Record<string, unknown> {
+  const raw = mock.child.stdin.write.mock.calls.at(-1)?.[0] as string;
+  return JSON.parse(raw.trim()) as Record<string, unknown>;
+}
+
+describe("JsonRpcConnection", () => {
+  let logger: ReturnType<typeof createMockLogger>;
+  let onRequest: ReturnType<typeof vi.fn>;
+  let onNotification: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    logger = createMockLogger();
+    onRequest = vi.fn().mockResolvedValue(undefined);
+    onNotification = vi.fn();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function createConnection(mock: ReturnType<typeof makeMockChild>, timeoutMs = 5000): JsonRpcConnection {
+    return new JsonRpcConnection(mock.child, logger, timeoutMs, onRequest, onNotification);
+  }
+
+  describe("line-buffered JSON-RPC parsing", () => {
+    it("parses a complete JSON-RPC success response", async () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      const promise = conn.request("test/method", { key: "value" });
+      const sent = lastSentMessage(mock);
+
+      mock.sendLine({ jsonrpc: "2.0", id: sent.id, result: { ok: true } });
+      const result = await promise;
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("handles data arriving in multiple chunks", async () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      const promise = conn.request("test/chunked", {});
+      const sent = lastSentMessage(mock);
+
+      const fullResponse = JSON.stringify({ jsonrpc: "2.0", id: sent.id, result: "chunked" });
+      const midpoint = Math.floor(fullResponse.length / 2);
+      mock.sendRaw(fullResponse.slice(0, midpoint));
+      mock.sendRaw(fullResponse.slice(midpoint) + "\n");
+
+      const result = await promise;
+      expect(result).toBe("chunked");
+    });
+
+    it("handles multiple messages in a single chunk", async () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      const promise1 = conn.request("test/first", {});
+      const id1 = lastSentMessage(mock).id;
+
+      const promise2 = conn.request("test/second", {});
+      const id2 = lastSentMessage(mock).id;
+
+      const combined =
+        JSON.stringify({ jsonrpc: "2.0", id: id1, result: "first" }) +
+        "\n" +
+        JSON.stringify({ jsonrpc: "2.0", id: id2, result: "second" }) +
+        "\n";
+      mock.sendRaw(combined);
+
+      expect(await promise1).toBe("first");
+      expect(await promise2).toBe("second");
+    });
+
+    it("skips empty lines between messages", async () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      const promise = conn.request("test/skipblanks", {});
+      const sent = lastSentMessage(mock);
+
+      mock.sendRaw("\n\n" + JSON.stringify({ jsonrpc: "2.0", id: sent.id, result: "ok" }) + "\n\n");
+      expect(await promise).toBe("ok");
+    });
+
+    it("logs error for invalid JSON and does not crash", () => {
+      const mock = makeMockChild();
+      createConnection(mock);
+
+      mock.sendRaw("this-is-not-json\n");
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ line: "this-is-not-json" }),
+        expect.stringContaining("invalid json"),
+      );
+    });
+  });
+
+  describe("response routing", () => {
+    it("resolves pending request on success response", async () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      const promise = conn.request("resolve/test", {});
+      const sent = lastSentMessage(mock);
+
+      mock.sendLine({ jsonrpc: "2.0", id: sent.id, result: 42 });
+      expect(await promise).toBe(42);
+    });
+
+    it("ignores success response with unknown id without crashing", () => {
+      const mock = makeMockChild();
+      createConnection(mock);
+
+      mock.sendLine({ jsonrpc: "2.0", id: 99999, result: "orphan" });
+      // No error should be logged for an orphaned success response
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error routing", () => {
+    it("rejects pending request on error response", async () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      const promise = conn.request("error/test", {});
+      const sent = lastSentMessage(mock);
+
+      mock.sendLine({
+        jsonrpc: "2.0",
+        id: sent.id,
+        error: { code: -32600, message: "invalid request" },
+      });
+
+      await expect(promise).rejects.toThrow("invalid request");
+    });
+
+    it("ignores error response with unknown id without crashing", () => {
+      const mock = makeMockChild();
+      createConnection(mock);
+
+      mock.sendLine({
+        jsonrpc: "2.0",
+        id: 99999,
+        error: { code: -32600, message: "orphan error" },
+      });
+      // No fatal error should be logged for an orphaned error response
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("request handling", () => {
+    it("invokes onRequest for incoming JSON-RPC requests", async () => {
+      const mock = makeMockChild();
+      createConnection(mock);
+
+      const incomingRequest: JsonRpcRequest = {
+        jsonrpc: "2.0",
+        id: 100,
+        method: "item/tool/call",
+        params: { name: "linear_graphql" },
+      };
+      mock.sendLine(incomingRequest);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(onRequest).toHaveBeenCalledWith(incomingRequest);
+    });
+
+    it("sends error response when onRequest handler throws", async () => {
+      onRequest.mockRejectedValueOnce(new Error("handler blew up"));
+      const mock = makeMockChild();
+      createConnection(mock);
+
+      mock.sendLine({ jsonrpc: "2.0", id: 200, method: "bad/method", params: {} });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "bad/method" }),
+        expect.stringContaining("failed to handle"),
+      );
+      const errorWrite = mock.child.stdin.write.mock.calls.find((call: unknown[]) => {
+        const parsed = JSON.parse(call[0] as string);
+        return parsed.id === 200 && parsed.error;
+      });
+      expect(errorWrite).toBeDefined();
+      const errorMsg = JSON.parse(errorWrite[0] as string);
+      expect(errorMsg.error.message).toBe("handler blew up");
+    });
+  });
+
+  describe("notification handling", () => {
+    it("invokes onNotification for incoming notifications", () => {
+      const mock = makeMockChild();
+      createConnection(mock);
+
+      mock.sendLine({ jsonrpc: "2.0", method: "status/update", params: { status: "running" } });
+      expect(onNotification).toHaveBeenCalledWith({
+        jsonrpc: "2.0",
+        method: "status/update",
+        params: { status: "running" },
+      });
+    });
+
+    it("logs notifications even without onNotification callback", () => {
+      const mock = makeMockChild();
+      // Create connection without onNotification callback
+      const conn = new JsonRpcConnection(mock.child, logger, 5000, onRequest);
+
+      mock.sendLine({ jsonrpc: "2.0", method: "log/info", params: { text: "hello" } });
+      expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ method: "log/info" }), expect.any(String));
+      expect(conn).toBeDefined();
+    });
+  });
+
+  describe("timeout handling", () => {
+    it("rejects with JsonRpcTimeoutError when response is not received in time", async () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock, 1000);
+
+      const promise = conn.request("slow/method", {});
+      vi.advanceTimersByTime(1001);
+
+      await expect(promise).rejects.toThrow(JsonRpcTimeoutError);
+      await expect(promise).rejects.toThrow("timed out waiting for slow/method");
+    });
+
+    it("clears timeout when response arrives before deadline", async () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock, 5000);
+
+      const promise = conn.request("fast/method", {});
+      const sent = lastSentMessage(mock);
+
+      vi.advanceTimersByTime(100);
+      mock.sendLine({ jsonrpc: "2.0", id: sent.id, result: "fast" });
+
+      const result = await promise;
+      expect(result).toBe("fast");
+
+      // Advancing past the original timeout should not cause issues
+      vi.advanceTimersByTime(10000);
+    });
+  });
+
+  describe("MAX_LINE_BYTES enforcement", () => {
+    it("closes connection when a line exceeds the size limit", () => {
+      const mock = makeMockChild();
+      createConnection(mock);
+
+      const oversizedData = "x".repeat(11 * 1024 * 1024);
+      mock.sendRaw(oversizedData);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ maxLineBytes: 10 * 1024 * 1024 }),
+        expect.stringContaining("exceeded maximum size"),
+      );
+      expect(mock.kill).toHaveBeenCalledWith("SIGTERM");
+    });
+  });
+
+  describe("graceful exit cleanup", () => {
+    it("rejects all pending requests when child exits", async () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      const promise1 = conn.request("pending/one", {});
+      const promise2 = conn.request("pending/two", {});
+
+      mock.exit();
+
+      await expect(promise1).rejects.toThrow("connection exited");
+      await expect(promise2).rejects.toThrow("connection exited");
+    });
+
+    it("rejects new requests after exit", async () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      mock.exit();
+      await expect(conn.request("post/exit", {})).rejects.toThrow("connection already exited");
+    });
+
+    it("does not send notifications after exit", () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      mock.exit();
+      conn.notify("noop/after-exit", {});
+      // The write call count should only include writes from before exit
+      const postExitWrites = mock.child.stdin.write.mock.calls.length;
+      conn.notify("noop/after-exit2", {});
+      expect(mock.child.stdin.write.mock.calls.length).toBe(postExitWrites);
+    });
+  });
+
+  describe("close()", () => {
+    it("sends SIGTERM to child process", () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      conn.close();
+      expect(mock.kill).toHaveBeenCalledWith("SIGTERM");
+    });
+
+    it("does not send SIGTERM if already exited", () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      mock.exit();
+      conn.close();
+      expect(mock.kill).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("notify()", () => {
+    it("sends a JSON-RPC notification without id", () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      conn.notify("test/notify", { data: "hello" });
+      const sent = lastSentMessage(mock);
+
+      expect(sent.jsonrpc).toBe("2.0");
+      expect(sent.method).toBe("test/notify");
+      expect(sent.params).toEqual({ data: "hello" });
+      expect(sent.id).toBeUndefined();
+    });
+  });
+
+  describe("stderr handling", () => {
+    it("logs stderr output as warnings", () => {
+      const mock = makeMockChild();
+      createConnection(mock);
+
+      mock.stderr.emit("data", Buffer.from("something went wrong\n"));
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ stderr: "something went wrong" }),
+        "codex stderr",
+      );
+    });
+  });
+
+  describe("stdin error handling", () => {
+    it("logs EPIPE as debug (child already exited)", () => {
+      const mock = makeMockChild();
+      createConnection(mock);
+
+      const epipeError = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+      mock.stdin.emit("error", epipeError);
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ error: "EPIPE" }),
+        expect.stringContaining("stdin write failed"),
+      );
+    });
+
+    it("logs ERR_STREAM_DESTROYED as debug", () => {
+      const mock = makeMockChild();
+      createConnection(mock);
+
+      const destroyedError = Object.assign(new Error("stream destroyed"), {
+        code: "ERR_STREAM_DESTROYED",
+      });
+      mock.stdin.emit("error", destroyedError);
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ error: "ERR_STREAM_DESTROYED" }),
+        expect.stringContaining("stdin write failed"),
+      );
+    });
+
+    it("logs unexpected stdin errors as error level", () => {
+      const mock = makeMockChild();
+      createConnection(mock);
+
+      const weirdError = Object.assign(new Error("something unexpected"), { code: "ENOENT" });
+      mock.stdin.emit("error", weirdError);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.stringContaining("something unexpected") }),
+        expect.stringContaining("unexpected stdin error"),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 19 unit tests for `handleCodexRequest` covering all method branches: approval auto-accept (commandExecution, fileChange, permissions), tool dispatch (linear_graphql, github_api, unsupported), fatal failure classification (user input, MCP elicitation, legacy methods), and default fallback
- Adds 26 unit tests for `JsonRpcConnection` covering line-buffered JSON-RPC parsing (chunked data, multi-message, empty lines, invalid JSON), response/error routing, request handling (onRequest callback, error propagation), notification handling, timeout enforcement, MAX_LINE_BYTES limits, graceful exit cleanup, close/notify/stderr/stdin behavior
- Uses mock child process (EventEmitter-based streams) for connection tests, vi.mock for codex-request-handler dependency isolation

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (zero errors, only pre-existing warnings)
- [x] `npm run format:check` passes
- [x] All 45 new tests pass
- [x] Full test suite passes (917 pass, 2 pre-existing flaky timeouts in agent-runner/workspace-manager unrelated to this change)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
