### PR TITLE
test: add property-based tests with fast-check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "agentation": "^2.3.3",
         "eslint": "^10.1.0",
         "eslint-plugin-sonarjs": "^4.0.2",
+        "fast-check": "^4.6.0",
         "husky": "^9.1.7",
         "jscpd": "^4.0.8",
         "knip": "^6.0.2",
@@ -3931,6 +3932,29 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6305,6 +6329,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.3.0.tgz",
+      "integrity": "sha512-1ws1Ab8fnsf4bvpL+SujgBnr3KFs5abgCLVzavBp+f2n8Ld5YTOZlkv/ccYPhu3X9s+MEeqPRMqKlJz/kWDK8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "agentation": "^2.3.3",
     "eslint": "^10.1.0",
     "eslint-plugin-sonarjs": "^4.0.2",
+    "fast-check": "^4.6.0",
     "husky": "^9.1.7",
     "jscpd": "^4.0.8",
     "knip": "^6.0.2",

--- a/tests/config/coercion.property.test.ts
+++ b/tests/config/coercion.property.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import {
+  asRecord,
+  asString,
+  asNumber,
+  asBoolean,
+  asStringArray,
+  asRecordArray,
+  asLooseStringArray,
+  asStringMap,
+  asNumberMap,
+} from "../../src/config/coercion.js";
+
+/** Arbitrary that produces any JSON-compatible value. */
+const anyValue = fc.oneof(
+  fc.string(),
+  fc.integer(),
+  fc.double(),
+  fc.boolean(),
+  fc.constant(null),
+  fc.constant(undefined),
+  fc.array(fc.string()),
+  fc.dictionary(fc.string(), fc.string()),
+);
+
+describe("property: asRecord", () => {
+  it("never throws for any input", () => {
+    fc.assert(
+      fc.property(anyValue, (value) => {
+        expect(() => asRecord(value)).not.toThrow();
+      }),
+    );
+  });
+
+  it("always returns a non-null object (not array)", () => {
+    fc.assert(
+      fc.property(anyValue, (value) => {
+        const result = asRecord(value);
+        expect(typeof result).toBe("object");
+        expect(result).not.toBeNull();
+        expect(Array.isArray(result)).toBe(false);
+      }),
+    );
+  });
+});
+
+describe("property: asString", () => {
+  it("always returns a string for any input", () => {
+    fc.assert(
+      fc.property(anyValue, (value) => {
+        expect(typeof asString(value)).toBe("string");
+      }),
+    );
+  });
+
+  it("preserves the original string when input is already a string", () => {
+    fc.assert(
+      fc.property(fc.string(), (value) => {
+        expect(asString(value)).toBe(value);
+      }),
+    );
+  });
+
+  it("returns the fallback for non-string inputs", () => {
+    fc.assert(
+      fc.property(
+        fc.oneof(fc.integer(), fc.boolean(), fc.constant(null), fc.constant(undefined)),
+        fc.string(),
+        (value, fallback) => {
+          expect(asString(value, fallback)).toBe(fallback);
+        },
+      ),
+    );
+  });
+});
+
+describe("property: asNumber", () => {
+  it("always returns a finite number or the fallback", () => {
+    fc.assert(
+      fc.property(anyValue, fc.integer(), (value, fallback) => {
+        const result = asNumber(value, fallback);
+        expect(typeof result).toBe("number");
+        expect(Number.isFinite(result)).toBe(true);
+      }),
+    );
+  });
+
+  it("returns the input for finite numbers", () => {
+    fc.assert(
+      fc.property(fc.double({ noNaN: true, noDefaultInfinity: true }), fc.integer(), (value, fallback) => {
+        expect(asNumber(value, fallback)).toBe(value);
+      }),
+    );
+  });
+
+  it("returns the fallback for NaN and Infinity", () => {
+    fc.assert(
+      fc.property(
+        fc.oneof(fc.constant(NaN), fc.constant(Infinity), fc.constant(-Infinity)),
+        fc.integer(),
+        (value, fallback) => {
+          expect(asNumber(value, fallback)).toBe(fallback);
+        },
+      ),
+    );
+  });
+});
+
+describe("property: asBoolean", () => {
+  it("always returns a boolean for any input", () => {
+    fc.assert(
+      fc.property(anyValue, fc.boolean(), (value, fallback) => {
+        expect(typeof asBoolean(value, fallback)).toBe("boolean");
+      }),
+    );
+  });
+
+  it("preserves original boolean when input is boolean", () => {
+    fc.assert(
+      fc.property(fc.boolean(), fc.boolean(), (value, fallback) => {
+        expect(asBoolean(value, fallback)).toBe(value);
+      }),
+    );
+  });
+});
+
+describe("property: asStringArray", () => {
+  it("always returns an array for any input", () => {
+    fc.assert(
+      fc.property(anyValue, (value) => {
+        const result = asStringArray(value, []);
+        expect(Array.isArray(result)).toBe(true);
+      }),
+    );
+  });
+
+  it("every element in the result is a non-empty string", () => {
+    fc.assert(
+      fc.property(fc.array(anyValue), (value) => {
+        const result = asStringArray(value, []);
+        for (const item of result) {
+          expect(typeof item).toBe("string");
+          expect(item.trim().length).toBeGreaterThan(0);
+        }
+      }),
+    );
+  });
+});
+
+describe("property: asRecordArray", () => {
+  it("always returns an array of plain objects", () => {
+    fc.assert(
+      fc.property(anyValue, (value) => {
+        const result = asRecordArray(value);
+        expect(Array.isArray(result)).toBe(true);
+        for (const item of result) {
+          expect(typeof item).toBe("object");
+          expect(item).not.toBeNull();
+          expect(Array.isArray(item)).toBe(false);
+        }
+      }),
+    );
+  });
+});
+
+describe("property: asLooseStringArray", () => {
+  it("always returns an array of strings (including empty)", () => {
+    fc.assert(
+      fc.property(anyValue, (value) => {
+        const result = asLooseStringArray(value);
+        expect(Array.isArray(result)).toBe(true);
+        for (const item of result) {
+          expect(typeof item).toBe("string");
+        }
+      }),
+    );
+  });
+});
+
+describe("property: asStringMap", () => {
+  it("always returns a Record with all string values", () => {
+    fc.assert(
+      fc.property(anyValue, (value) => {
+        const result = asStringMap(value);
+        expect(typeof result).toBe("object");
+        expect(result).not.toBeNull();
+        for (const val of Object.values(result)) {
+          expect(typeof val).toBe("string");
+        }
+      }),
+    );
+  });
+});
+
+describe("property: asNumberMap", () => {
+  it("always returns a Record with all finite number values", () => {
+    fc.assert(
+      fc.property(anyValue, (value) => {
+        const result = asNumberMap(value);
+        expect(typeof result).toBe("object");
+        expect(result).not.toBeNull();
+        for (const val of Object.values(result)) {
+          expect(typeof val).toBe("number");
+          expect(Number.isFinite(val)).toBe(true);
+        }
+      }),
+    );
+  });
+});

--- a/tests/config/resolvers.property.test.ts
+++ b/tests/config/resolvers.property.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import { resolveConfigString, resolvePathConfigString } from "../../src/config/resolvers.js";
+
+describe("property: resolveConfigString", () => {
+  it("always returns a string", () => {
+    fc.assert(
+      fc.property(
+        fc.oneof(fc.string(), fc.integer(), fc.boolean(), fc.constant(null), fc.constant(undefined)),
+        (value) => {
+          expect(typeof resolveConfigString(value)).toBe("string");
+        },
+      ),
+    );
+  });
+
+  it("is idempotent for literal strings without env markers", () => {
+    fc.assert(
+      fc.property(
+        fc.string().filter((s) => !s.startsWith("$") && !s.startsWith("~") && !s.includes("$TMPDIR")),
+        (value) => {
+          const once = resolveConfigString(value);
+          const twice = resolveConfigString(once);
+          expect(twice).toBe(once);
+        },
+      ),
+    );
+  });
+
+  it("output never contains $SECRET: markers when all secrets are provided", () => {
+    fc.assert(
+      fc.property(fc.stringMatching(/^\$SECRET:[\w.-]+$/), fc.string({ minLength: 1 }), (secretRef, secretValue) => {
+        const secretName = secretRef.slice("$SECRET:".length);
+        const resolver = (name: string) => (name === secretName ? secretValue : undefined);
+        const result = resolveConfigString(secretRef, resolver);
+        expect(result).not.toContain("$SECRET:");
+      }),
+    );
+  });
+
+  it("returns the literal for strings that are not env/secret references", () => {
+    fc.assert(
+      fc.property(
+        fc.string().filter((s) => !s.startsWith("$") && !s.startsWith("~") && !s.includes("$TMPDIR")),
+        (value) => {
+          expect(resolveConfigString(value)).toBe(value);
+        },
+      ),
+    );
+  });
+
+  it("returns empty string for non-string inputs", () => {
+    fc.assert(
+      fc.property(fc.oneof(fc.integer(), fc.boolean(), fc.constant(null), fc.constant(undefined)), (value) => {
+        expect(resolveConfigString(value)).toBe("");
+      }),
+    );
+  });
+});
+
+describe("property: resolvePathConfigString", () => {
+  it("always returns a string", () => {
+    fc.assert(
+      fc.property(
+        fc.oneof(fc.string(), fc.integer(), fc.boolean(), fc.constant(null), fc.constant(undefined)),
+        (value) => {
+          expect(typeof resolvePathConfigString(value)).toBe("string");
+        },
+      ),
+    );
+  });
+
+  it("returns empty string for non-string inputs", () => {
+    fc.assert(
+      fc.property(fc.oneof(fc.integer(), fc.boolean(), fc.constant(null), fc.constant(undefined)), (value) => {
+        expect(resolvePathConfigString(value)).toBe("");
+      }),
+    );
+  });
+
+  it("output contains no unresolved $VAR patterns when env vars are set", () => {
+    fc.assert(
+      fc.property(
+        fc.tuple(fc.stringMatching(/^[A-Za-z_]\w{0,10}$/), fc.stringMatching(/^\w{1,20}$/)),
+        ([envName, envValue]) => {
+          const original = process.env[envName];
+          try {
+            process.env[envName] = envValue;
+            const input = `/$${envName}/subpath`;
+            const result = resolvePathConfigString(input);
+            expect(result).not.toContain(`$${envName}`);
+          } finally {
+            if (original === undefined) {
+              delete process.env[envName];
+            } else {
+              process.env[envName] = original;
+            }
+          }
+        },
+      ),
+    );
+  });
+});

--- a/tests/workspace/paths.property.test.ts
+++ b/tests/workspace/paths.property.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+import path from "node:path";
+
+import { sanitizeIdentifier, isWithinRoot, resolveWorkspacePath } from "../../src/workspace/paths.js";
+
+/** Regex matching only safe filesystem characters: alphanumeric, dot, hyphen, underscore. */
+const SAFE_CHARS = /^[\w.-]*$/;
+
+/**
+ * Arbitrary for directory roots: absolute paths with at least one
+ * alphanumeric-leading segment to avoid edge cases like "/." resolving to "/".
+ */
+const rootArb = fc.stringMatching(/^\/[a-z]\w{0,19}$/);
+
+/**
+ * Arbitrary for child path segments: alphanumeric-leading names that
+ * cannot be confused with ".." traversal segments.
+ */
+const childArb = fc.stringMatching(/^[a-z]\w{0,19}$/);
+
+describe("property: sanitizeIdentifier", () => {
+  it("output contains only safe filesystem characters", () => {
+    fc.assert(
+      fc.property(fc.string(), (input) => {
+        const result = sanitizeIdentifier(input);
+        expect(result).toMatch(SAFE_CHARS);
+      }),
+    );
+  });
+
+  it("preserves already-safe identifiers unchanged", () => {
+    fc.assert(
+      fc.property(fc.stringMatching(/^[\w.-]{0,50}$/), (input) => {
+        expect(sanitizeIdentifier(input)).toBe(input);
+      }),
+    );
+  });
+
+  it("output has the same length as the input", () => {
+    fc.assert(
+      fc.property(fc.string(), (input) => {
+        expect(sanitizeIdentifier(input).length).toBe(input.length);
+      }),
+    );
+  });
+
+  it("is idempotent -- sanitizing twice gives the same result", () => {
+    fc.assert(
+      fc.property(fc.string(), (input) => {
+        const once = sanitizeIdentifier(input);
+        const twice = sanitizeIdentifier(once);
+        expect(twice).toBe(once);
+      }),
+    );
+  });
+});
+
+describe("property: isWithinRoot", () => {
+  it("returns true when candidate is a child of root", () => {
+    fc.assert(
+      fc.property(rootArb, childArb, (root, child) => {
+        const candidate = path.join(root, child);
+        expect(isWithinRoot(root, candidate)).toBe(true);
+      }),
+    );
+  });
+
+  it("returns true when candidate equals root", () => {
+    fc.assert(
+      fc.property(rootArb, (root) => {
+        expect(isWithinRoot(root, root)).toBe(true);
+      }),
+    );
+  });
+
+  it("returns false for paths that escape root via .. traversal", () => {
+    fc.assert(
+      fc.property(rootArb, childArb, (root, suffix) => {
+        const candidate = path.resolve(root, "..", suffix);
+        expect(isWithinRoot(root, candidate)).toBe(false);
+      }),
+    );
+  });
+
+  it("returns true for deeply nested children", () => {
+    fc.assert(
+      fc.property(rootArb, childArb, childArb, (root, mid, leaf) => {
+        const candidate = path.join(root, mid, leaf);
+        expect(isWithinRoot(root, candidate)).toBe(true);
+      }),
+    );
+  });
+});
+
+describe("property: resolveWorkspacePath", () => {
+  it("returns a path within the workspace root for safe identifiers", () => {
+    fc.assert(
+      fc.property(rootArb, childArb, (root, identifier) => {
+        const { workspacePath, workspaceKey } = resolveWorkspacePath(root, identifier);
+        expect(isWithinRoot(root, workspacePath)).toBe(true);
+        expect(workspaceKey).toMatch(SAFE_CHARS);
+      }),
+    );
+  });
+
+  it("sanitizes the identifier before building the path", () => {
+    fc.assert(
+      fc.property(rootArb, fc.string({ minLength: 1, maxLength: 30 }), (root, identifier) => {
+        const { workspaceKey } = resolveWorkspacePath(root, identifier);
+        expect(workspaceKey).toBe(sanitizeIdentifier(identifier));
+      }),
+    );
+  });
+
+  it("never produces a path that escapes root after sanitization", () => {
+    fc.assert(
+      fc.property(rootArb, fc.string({ minLength: 1, maxLength: 30 }), (root, identifier) => {
+        // sanitizeIdentifier replaces path separators with underscores,
+        // so traversal attempts become harmless after sanitization
+        const { workspacePath } = resolveWorkspacePath(root, identifier);
+        expect(isWithinRoot(root, workspacePath)).toBe(true);
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `fast-check` as a dev dependency for property-based testing
- Add property tests for config coercion functions (`asRecord`, `asString`, `asNumber`, `asBoolean`, `asStringArray`, `asRecordArray`, `asLooseStringArray`, `asStringMap`, `asNumberMap`) -- 13 properties
- Add property tests for config resolvers (`resolveConfigString`, `resolvePathConfigString`) -- 8 properties covering return type safety, idempotency, secret resolution, and env var expansion
- Add property tests for workspace paths (`sanitizeIdentifier`, `isWithinRoot`, `resolveWorkspacePath`) -- 11 properties covering character safety, idempotency, length preservation, traversal prevention, and root containment

## Test plan
- [x] All 35 new property tests pass
- [x] Full test suite (905 tests) passes with no regressions
- [x] Build, lint, and format checks pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
