### PR TITLE
test(e2e): add setup wizard walkthrough smoke tests

### DIFF
--- a/tests/e2e/mocks/api-mock.ts
+++ b/tests/e2e/mocks/api-mock.ts
@@ -49,11 +49,39 @@ export async function installApiMock(page: Page, overrides: ApiMockOverrides = {
 
   // Setup
   await page.route("**/api/v1/setup/status", (route) => json(route, setupStatus));
+  await page.route("**/api/v1/setup/master-key", (route) => json(route, { key: "sym_test_master_key_abc123" }, 201));
+  await page.route("**/api/v1/setup/linear-projects", (route) =>
+    json(route, {
+      projects: [
+        { id: "proj-1", name: "My Project", slugId: "my-project", teamKey: "MYP" },
+        { id: "proj-2", name: "Other Project", slugId: "other-project", teamKey: "OTH" },
+      ],
+    }),
+  );
+  await page.route("**/api/v1/setup/linear-project", (route) => json(route, { ok: true }));
+  await page.route("**/api/v1/setup/repo-routes", (route) => json(route, { routes: [] }));
+  await page.route("**/api/v1/setup/repo-route", (route) => json(route, { ok: true }));
+  await page.route("**/api/v1/setup/openai-key", (route) => json(route, { valid: true }));
+  await page.route("**/api/v1/setup/codex-auth", (route) => json(route, { ok: true }));
+  await page.route("**/api/v1/setup/github-token", (route) => json(route, { valid: true }));
+  await page.route("**/api/v1/setup/detect-default-branch", (route) => json(route, { defaultBranch: "main" }));
+  await page.route("**/api/v1/setup/reset", (route) => json(route, { ok: true }));
   await page.route("**/api/v1/setup/create-test-issue", (route) =>
     json(route, { ok: true, issueIdentifier: "TST-1", issueUrl: "https://linear.app/test/issue/TST-1" }),
   );
   await page.route("**/api/v1/setup/create-label", (route) =>
     json(route, { ok: true, labelId: "label-1", labelName: "symphony" }),
+  );
+  await page.route("**/api/v1/setup/create-project", (route) =>
+    json(route, {
+      project: {
+        id: "proj-new",
+        name: "New Project",
+        slugId: "new-project",
+        teamKey: "NEW",
+        url: "https://linear.app/test/project/new",
+      },
+    }),
   );
 
   // State & Runtime

--- a/tests/e2e/pages/setup.page.ts
+++ b/tests/e2e/pages/setup.page.ts
@@ -9,10 +9,16 @@ export class SetupPage extends BasePage {
     super(page);
   }
 
-  /** Navigate to the setup page. */
+  /** Navigate to the setup page and wait for content. */
   async navigate(): Promise<void> {
     await this.goto("/setup");
-    await this.waitForReady();
+    await this.waitForPageContent();
+  }
+
+  /** Navigate to setup and wait for the master key to be generated. */
+  async navigateAndWaitForKey(): Promise<void> {
+    await this.navigate();
+    await this.keyValue.waitFor({ state: "visible", timeout: 5000 });
   }
 
   /** Check if the setup page is currently displayed. */
@@ -21,12 +27,140 @@ export class SetupPage extends BasePage {
     return path === "/setup";
   }
 
-  /** Get the page heading. */
+  // ── Headings & intro ────────────────────────────────────────────
+
+  /** Get the welcome heading shown on the master-key step. */
+  get welcomeHeading(): Locator {
+    return this.page.locator(".setup-intro-heading");
+  }
+
+  /** Get the page heading (generic). */
   get heading(): Locator {
     return this.page.locator(".page-title, h1").first();
   }
 
-  /** Get all setup step elements. */
+  // ── Step indicator ──────────────────────────────────────────────
+
+  /** Container for the step indicator row. */
+  get stepIndicatorRow(): Locator {
+    return this.page.locator(".setup-steps");
+  }
+
+  /** All individual step indicator items. */
+  get stepIndicators(): Locator {
+    return this.page.locator(".setup-step-indicator");
+  }
+
+  /** The currently active step indicator. */
+  get activeStepIndicator(): Locator {
+    return this.page.locator(".setup-step-indicator.is-active");
+  }
+
+  /** Step indicators marked as done. */
+  get doneStepIndicators(): Locator {
+    return this.page.locator(".setup-step-indicator.is-done");
+  }
+
+  // ── Step content ────────────────────────────────────────────────
+
+  /** The setup content area that wraps the current step. */
+  get stepContent(): Locator {
+    return this.page.locator(".setup-content");
+  }
+
+  /** Step title inside the content area. */
+  get stepTitle(): Locator {
+    return this.page.locator(".setup-title, .setup-title-row").first();
+  }
+
+  // ── Master key step ─────────────────────────────────────────────
+
+  /** The generated key display area. */
+  get keyDisplay(): Locator {
+    return this.page.locator(".setup-key-display");
+  }
+
+  /** The key value text. */
+  get keyValue(): Locator {
+    return this.page.locator(".setup-key-value");
+  }
+
+  // ── Linear project step ─────────────────────────────────────────
+
+  /** The Linear API key input. */
+  get linearApiKeyInput(): Locator {
+    return this.page.locator("#setup-linear-api-key");
+  }
+
+  /** The project selection grid. */
+  get projectGrid(): Locator {
+    return this.page.locator(".setup-project-grid");
+  }
+
+  /** Individual project cards in the grid. */
+  get projectCards(): Locator {
+    return this.page.locator(".setup-project-card");
+  }
+
+  /** The currently selected project card. */
+  get selectedProjectCard(): Locator {
+    return this.page.locator(".setup-project-card.is-selected");
+  }
+
+  // ── Repo config step ────────────────────────────────────────────
+
+  /** Repo URL input field. */
+  get repoUrlInput(): Locator {
+    return this.page.locator("#setup-repo-url");
+  }
+
+  // ── GitHub token step ───────────────────────────────────────────
+
+  /** GitHub token input field. */
+  get githubTokenInput(): Locator {
+    return this.page.locator("#setup-github-token");
+  }
+
+  // ── Done step ───────────────────────────────────────────────────
+
+  /** The done step container. */
+  get doneContainer(): Locator {
+    return this.page.locator(".setup-done");
+  }
+
+  /** The done step title. */
+  get doneTitle(): Locator {
+    return this.page.locator(".setup-done-title");
+  }
+
+  /** The "Go to Dashboard" button on the done step. */
+  get goToDashboardButton(): Locator {
+    return this.page.getByRole("button", { name: "Go to Dashboard" });
+  }
+
+  // ── Shared controls ─────────────────────────────────────────────
+
+  /** Primary "Next" button. */
+  get nextButton(): Locator {
+    return this.page.locator("button.mc-button.is-primary", { hasText: /Next|Saving/ });
+  }
+
+  /** "Skip" button (ghost variant). */
+  get skipButton(): Locator {
+    return this.page.locator("button.mc-button.is-ghost", { hasText: /Skip/ });
+  }
+
+  /** "Verify Key" / "Re-verify" button on the Linear step. */
+  get verifyKeyButton(): Locator {
+    return this.page.locator("button.mc-button.is-primary", { hasText: /Verify|Re-verify|Verifying/ });
+  }
+
+  /** Error message display. */
+  get errorMessage(): Locator {
+    return this.page.locator(".setup-error");
+  }
+
+  /** All setup step elements (legacy locator). */
   get steps(): Locator {
     return this.page.locator(".setup-step, .setup-card, [class*='setup']");
   }

--- a/tests/e2e/specs/smoke/setup-wizard.smoke.spec.ts
+++ b/tests/e2e/specs/smoke/setup-wizard.smoke.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect } from "../../fixtures/test";
+import { SetupPage } from "../../pages/setup.page";
+
+test.describe("Setup Wizard Walkthrough", () => {
+  let setup: SetupPage;
+
+  test.beforeEach(async ({ page, apiMock }) => {
+    setup = new SetupPage(page);
+    const scenario = apiMock.scenario().withSetupUnconfigured().build();
+    await apiMock.install(scenario);
+  });
+
+  // ── Step indicator ──────────────────────────────────────────────
+
+  test("renders step indicators with five steps", async () => {
+    await setup.navigate();
+
+    await expect(setup.stepIndicatorRow).toBeVisible({ timeout: 5000 });
+    await expect(setup.stepIndicators).toHaveCount(5);
+  });
+
+  test("first step is active on initial load", async () => {
+    await setup.navigate();
+
+    await expect(setup.activeStepIndicator).toBeVisible({ timeout: 5000 });
+    await expect(setup.activeStepIndicator).toContainText("Protect secrets");
+  });
+
+  // ── Master key step ─────────────────────────────────────────────
+
+  test("shows welcome heading on master key step", async () => {
+    await setup.navigate();
+
+    await expect(setup.welcomeHeading).toBeVisible({ timeout: 5000 });
+    await expect(setup.welcomeHeading).toContainText("Welcome to Symphony");
+  });
+
+  test("generates and displays master key", async () => {
+    await setup.navigateAndWaitForKey();
+
+    await expect(setup.keyDisplay).toBeVisible();
+    await expect(setup.keyValue).toContainText("sym_test_master_key_abc123");
+  });
+
+  test("advances from master key to Linear project step", async ({ page }) => {
+    await setup.navigateAndWaitForKey();
+    await setup.nextButton.click();
+
+    await expect(setup.activeStepIndicator).toContainText("Connect Linear");
+    await expect(setup.doneStepIndicators).toHaveCount(1);
+    await expect(page.getByText("Connect to Linear")).toBeVisible();
+  });
+
+  // ── Linear project step ─────────────────────────────────────────
+
+  test("Linear step shows API key input and verify button", async () => {
+    await setup.navigateAndWaitForKey();
+    await setup.nextButton.click();
+
+    await expect(setup.linearApiKeyInput).toBeVisible({ timeout: 5000 });
+    await expect(setup.verifyKeyButton).toBeVisible();
+    await expect(setup.verifyKeyButton).toBeDisabled();
+  });
+
+  test("verifying Linear key shows project grid", async ({ page }) => {
+    await setup.navigateAndWaitForKey();
+    await setup.nextButton.click();
+
+    await setup.linearApiKeyInput.fill("lin_api_test_key_123");
+    await expect(setup.verifyKeyButton).toBeEnabled();
+    await setup.verifyKeyButton.click();
+
+    await expect(setup.projectGrid).toBeVisible({ timeout: 5000 });
+    await expect(setup.projectCards).toHaveCount(2);
+    await expect(page.getByText("My Project")).toBeVisible();
+    await expect(page.getByText("Other Project")).toBeVisible();
+  });
+
+  test("selecting a project enables Next button", async () => {
+    await setup.navigateAndWaitForKey();
+    await setup.nextButton.click();
+
+    await setup.linearApiKeyInput.fill("lin_api_test_key_123");
+    await setup.verifyKeyButton.click();
+    await expect(setup.projectGrid).toBeVisible({ timeout: 5000 });
+
+    await expect(setup.nextButton).toBeDisabled();
+    await setup.projectCards.first().click();
+    await expect(setup.selectedProjectCard).toBeVisible();
+    await expect(setup.nextButton).toBeEnabled();
+  });
+
+  // ── Step navigation via indicator ───────────────────────────────
+
+  test("clicking step indicator navigates between steps", async ({ page }) => {
+    await setup.navigateAndWaitForKey();
+
+    await setup.stepIndicators.nth(1).click();
+    await expect(setup.activeStepIndicator).toContainText("Connect Linear");
+    await expect(page.getByText("Connect to Linear")).toBeVisible();
+
+    await setup.stepIndicators.nth(4).click();
+    await expect(setup.activeStepIndicator).toContainText("Add GitHub");
+    await expect(page.getByText("Add GitHub access")).toBeVisible();
+  });
+
+  // ── Skip behavior ──────────────────────────────────────────────
+
+  test("skip button on Linear step advances to GitHub step", async ({ page }) => {
+    await setup.navigateAndWaitForKey();
+    await setup.nextButton.click();
+
+    await expect(page.getByText("Connect to Linear")).toBeVisible({ timeout: 5000 });
+    await setup.skipButton.click();
+
+    await expect(setup.activeStepIndicator).toContainText("Add GitHub");
+    await expect(page.getByText("Add GitHub access")).toBeVisible();
+  });
+
+  test("skip on GitHub step advances to done", async () => {
+    await setup.navigateAndWaitForKey();
+
+    await setup.stepIndicators.nth(4).click();
+    await expect(setup.skipButton).toBeVisible({ timeout: 5000 });
+    await setup.skipButton.click();
+
+    await expect(setup.doneContainer).toBeVisible({ timeout: 5000 });
+    await expect(setup.doneTitle).toContainText("You're all set");
+  });
+
+  // ── Done step ───────────────────────────────────────────────────
+
+  test("done step shows completion state and dashboard button", async ({ page }) => {
+    await setup.navigateAndWaitForKey();
+
+    // Navigate to GitHub step, then skip to done
+    await setup.stepIndicators.nth(4).click();
+    await expect(setup.skipButton).toBeVisible({ timeout: 5000 });
+    await setup.skipButton.click();
+
+    await expect(setup.doneContainer).toBeVisible({ timeout: 5000 });
+    await expect(setup.doneTitle).toContainText("You're all set");
+    await expect(setup.stepIndicatorRow).toHaveCount(0);
+    await expect(setup.goToDashboardButton).toBeVisible();
+    await expect(page.getByText("Create a test issue")).toBeVisible();
+    await expect(page.getByText("Create Symphony label")).toBeVisible();
+  });
+
+  // ── Full walkthrough ────────────────────────────────────────────
+
+  test("full wizard walkthrough from master key to done", async ({ page }) => {
+    await setup.navigateAndWaitForKey();
+
+    // Step 1: Master Key
+    await expect(setup.welcomeHeading).toBeVisible();
+    await setup.nextButton.click();
+
+    // Step 2: Linear Project -- verify key and select project
+    await expect(page.getByText("Connect to Linear")).toBeVisible({ timeout: 5000 });
+    await expect(setup.doneStepIndicators).toHaveCount(1);
+    await setup.linearApiKeyInput.fill("lin_api_test_key_123");
+    await setup.verifyKeyButton.click();
+    await expect(setup.projectGrid).toBeVisible({ timeout: 5000 });
+    await setup.projectCards.first().click();
+    await setup.nextButton.click();
+
+    // Step 3: Repo Config
+    await expect(setup.activeStepIndicator).toContainText("Link repo", { timeout: 5000 });
+    await expect(setup.doneStepIndicators).toHaveCount(2);
+    await setup.skipButton.click();
+
+    // Step 4: OpenAI Key
+    await expect(setup.activeStepIndicator).toContainText("Add OpenAI", { timeout: 5000 });
+    await expect(setup.doneStepIndicators).toHaveCount(3);
+    await setup.skipButton.click();
+
+    // Step 5: GitHub Token
+    await expect(setup.activeStepIndicator).toContainText("Add GitHub", { timeout: 5000 });
+    await expect(setup.doneStepIndicators).toHaveCount(4);
+    await setup.skipButton.click();
+
+    // Done
+    await expect(setup.doneContainer).toBeVisible({ timeout: 5000 });
+    await expect(setup.doneTitle).toContainText("You're all set");
+    await expect(setup.goToDashboardButton).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 13 Playwright E2E smoke tests for the setup wizard walkthrough flow in `tests/e2e/specs/smoke/setup-wizard.smoke.spec.ts`
- Extends `SetupPage` POM with locators for wizard step indicators, master key display, Linear project grid, done state, and shared controls (Next, Skip, Verify buttons)
- Adds mock API routes for all setup wizard endpoints (master-key, linear-projects, linear-project, repo-routes, openai-key, github-token, etc.) in `api-mock.ts`

## Test plan

- [x] All 13 new smoke tests pass: `npx playwright test tests/e2e/specs/smoke/setup-wizard.smoke.spec.ts --project=smoke` (13 passed, 4.2s)
- [x] Build passes: `npm run build`
- [x] Lint passes: `npm run lint` (only pre-existing warnings)
- [x] Format check passes: `npm run format:check`
- [x] Unit tests pass: `npm test` (872 passed, 1 pre-existing flaky failure in agent-runner unrelated to this PR)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
