### PR TITLE
test(e2e): add logs page and attempt detail smoke tests

### DIFF
--- a/tests/e2e/pages/logs.page.ts
+++ b/tests/e2e/pages/logs.page.ts
@@ -1,0 +1,91 @@
+import type { Page, Locator } from "@playwright/test";
+import { BasePage } from "./base.page";
+
+/**
+ * Page Object Model for the Logs page ("/issues/:id/logs" and "/logs/:id").
+ */
+export class LogsPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /** Navigate to the issue logs page via the /issues/:id/logs route. */
+  async navigateIssueLogs(identifier: string): Promise<void> {
+    await this.goto(`/issues/${encodeURIComponent(identifier)}/logs`);
+    await this.waitForPageContent();
+  }
+
+  /** Navigate to the live logs page via the /logs/:id route. */
+  async navigateLiveLogs(identifier: string): Promise<void> {
+    await this.goto(`/logs/${encodeURIComponent(identifier)}`);
+    await this.waitForPageContent();
+  }
+
+  // ── Header ───────────────────────────────────────────────────────────
+
+  get header(): Locator {
+    return this.page.locator(".logs-header");
+  }
+
+  get breadcrumb(): Locator {
+    return this.page.locator(".logs-breadcrumb");
+  }
+
+  // ── Mode Tabs ────────────────────────────────────────────────────────
+
+  get liveButton(): Locator {
+    return this.page.locator(".logs-live-btn");
+  }
+
+  get archiveButton(): Locator {
+    return this.page.locator(".mc-button-segment button").filter({ hasText: "Archive" });
+  }
+
+  // ── Filter Controls ──────────────────────────────────────────────────
+
+  get controlBar(): Locator {
+    return this.page.locator(".logs-control");
+  }
+
+  get searchInput(): Locator {
+    return this.page.locator(".logs-search");
+  }
+
+  get typeChips(): Locator {
+    return this.page.locator(".mc-chip.is-interactive");
+  }
+
+  get activeTypeChip(): Locator {
+    return this.page.locator(".mc-chip.is-interactive.is-active");
+  }
+
+  // ── Log Rows ─────────────────────────────────────────────────────────
+
+  get scrollArea(): Locator {
+    return this.page.locator(".logs-scroll");
+  }
+
+  get logRows(): Locator {
+    return this.page.locator(".mc-log-row");
+  }
+
+  get logMessages(): Locator {
+    return this.page.locator(".mc-log-message");
+  }
+
+  get logTimestamps(): Locator {
+    return this.page.locator(".mc-log-time");
+  }
+
+  // ── View Actions ─────────────────────────────────────────────────────
+
+  get viewActions(): Locator {
+    return this.page.locator(".logs-view-actions");
+  }
+
+  // ── Empty State ──────────────────────────────────────────────────────
+
+  get emptyState(): Locator {
+    return this.page.locator(".mc-empty-state, [class*='empty-state']");
+  }
+}

--- a/tests/e2e/specs/smoke/logs-detail.smoke.spec.ts
+++ b/tests/e2e/specs/smoke/logs-detail.smoke.spec.ts
@@ -1,0 +1,124 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "../../fixtures/test";
+import { LogsPage } from "../../pages/logs.page";
+import { buildIssueDrilldownScenario } from "../../mocks/scenarios/issue-drilldown";
+
+/** Navigate to a path and wait for the SPA shell + page content to render. */
+async function gotoAndWait(page: Page, path: string): Promise<void> {
+  await page.goto(path);
+  await page.waitForSelector("#main-content", { state: "attached", timeout: 10_000 });
+  await page.waitForFunction(() => {
+    const outlet = document.getElementById("main-content");
+    return outlet && outlet.children.length > 0;
+  });
+}
+
+test.describe("Logs Page & Attempt Detail Smoke", () => {
+  test.beforeEach(async ({ apiMock }) => {
+    await apiMock.install(buildIssueDrilldownScenario());
+  });
+
+  // ── Logs Page ────────────────────────────────────────────────────────
+
+  test("logs page loads via /issues/:id/logs with header and breadcrumb", async ({ page }) => {
+    const logs = new LogsPage(page);
+    await logs.navigateIssueLogs("SYM-42");
+
+    await expect(logs.header).toBeVisible({ timeout: 5000 });
+    await expect(logs.breadcrumb).toContainText("SYM-42", { timeout: 5000 });
+  });
+
+  test("logs page loads via /logs/:id in live mode", async ({ page }) => {
+    const logs = new LogsPage(page);
+    await logs.navigateLiveLogs("SYM-42");
+
+    await expect(logs.header).toBeVisible({ timeout: 5000 });
+    await expect(logs.breadcrumb).toContainText("SYM-42", { timeout: 5000 });
+  });
+
+  test("logs page renders filter controls and mode toggles", async ({ page }) => {
+    const logs = new LogsPage(page);
+    await logs.navigateIssueLogs("SYM-42");
+
+    await expect(logs.controlBar).toBeVisible({ timeout: 5000 });
+    await expect(logs.searchInput).toBeVisible({ timeout: 5000 });
+    await expect(logs.liveButton).toBeVisible({ timeout: 5000 });
+    await expect(logs.archiveButton).toBeVisible({ timeout: 5000 });
+  });
+
+  test("logs page shows recent events with log rows and timestamps", async ({ page }) => {
+    const logs = new LogsPage(page);
+    await logs.navigateLiveLogs("SYM-42");
+
+    // The drilldown scenario has events: "Agent started attempt #2" and "Agent crashed during file write"
+    await expect(page.getByText("Agent started attempt #2")).toBeVisible({ timeout: 5000 });
+
+    // Log rows with timestamps should render
+    await expect(logs.logRows.first()).toBeVisible({ timeout: 5000 });
+    await expect(logs.logTimestamps.first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test("logs page shows event type chips and view actions", async ({ page }) => {
+    const logs = new LogsPage(page);
+    await logs.navigateLiveLogs("SYM-42");
+
+    // Should have at least the "All events" chip
+    await expect(logs.typeChips.first()).toBeVisible({ timeout: 5000 });
+    await expect(logs.typeChips.first()).toContainText("All events");
+
+    // View actions (density, auto-scroll, expand, copy) should be visible
+    await expect(logs.viewActions).toBeVisible({ timeout: 5000 });
+  });
+
+  // ── Runs Page ────────────────────────────────────────────────────────
+
+  test("runs page loads and shows run history with attempts", async ({ page }) => {
+    await gotoAndWait(page, "/issues/SYM-42/runs");
+
+    // The drilldown scenario has 2 attempts
+    await expect(page.getByText("Run History")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("#1").first()).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("#2").first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test("clicking an attempt row shows attempt detail panel", async ({ page }) => {
+    await gotoAndWait(page, "/issues/SYM-42/runs");
+
+    // Click the first attempt row (#1 - failed attempt)
+    const firstRow = page.locator(".runs-row").first();
+    await expect(firstRow).toBeVisible({ timeout: 5000 });
+    await firstRow.click();
+
+    // The detail panel should show summary info
+    await expect(page.locator(".runs-detail-panel").first()).toBeVisible({ timeout: 5000 });
+  });
+
+  // ── Attempt Detail ───────────────────────────────────────────────────
+
+  test("attempt detail shows title, model, and token usage", async ({ page }) => {
+    await gotoAndWait(page, "/attempts/att-002");
+
+    // Issue title
+    await expect(page.getByText("Fix authentication bug")).toBeVisible({ timeout: 5000 });
+    // Model
+    await expect(page.getByText("o3-mini").first()).toBeVisible({ timeout: 5000 });
+    // Token usage (formatted with compact numbers)
+    await expect(page.getByText(/total/i).first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test("attempt detail shows status and workspace metadata", async ({ page }) => {
+    await gotoAndWait(page, "/attempts/att-002");
+
+    // Status chip for the running attempt
+    await expect(page.getByText("running").first()).toBeVisible({ timeout: 5000 });
+    // Workspace path from the scenario
+    await expect(page.getByText("/tmp/workspace/sym-42")).toBeVisible({ timeout: 5000 });
+  });
+
+  test("attempt detail has back navigation to issue", async ({ page }) => {
+    await gotoAndWait(page, "/attempts/att-002");
+
+    // Should show a "Back to SYM-42" button
+    await expect(page.getByText(/Back to SYM-42/i)).toBeVisible({ timeout: 5000 });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `LogsPage` POM (`tests/e2e/pages/logs.page.ts`) extending `BasePage` with locators for logs header, breadcrumb, mode tabs, filter controls, log rows, timestamps, and view actions
- Add 10 smoke tests in `tests/e2e/specs/smoke/logs-detail.smoke.spec.ts` covering the logs page, runs page, and attempt detail page
- Reuse the existing `buildIssueDrilldownScenario` for mock data setup

## Test plan
- [x] All 10 new E2E smoke tests pass with full parallelism (2.9s)
- [x] Existing 872 Vitest unit tests pass
- [x] Build, lint, and format checks pass
- [x] Tests cover both `/issues/:id/logs` and `/logs/:id` route variants
- [x] Tests verify logs UI (header, breadcrumb, filter controls, mode toggles, event chips, log rows, timestamps, view actions)
- [x] Tests verify runs page (run history, attempt rows, row click interaction)
- [x] Tests verify attempt detail (title, model, tokens, status, workspace, back navigation)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
