### PR TITLE
test(agent-runner): add notification-handler and session-init tests

### DIFF
--- a/tests/agent-runner/notification-handler.test.ts
+++ b/tests/agent-runner/notification-handler.test.ts
@@ -1,0 +1,430 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { handleNotification } from "../../src/agent-runner/notification-handler.js";
+import { createTurnState, type TurnState } from "../../src/agent-runner/turn-state.js";
+import type { Issue } from "../../src/core/types.js";
+
+const FIXED_ISO = "2024-01-01T00:00:00.000Z";
+
+function makeIssue(overrides?: Partial<Issue>): Issue {
+  return {
+    id: "issue-1",
+    identifier: "ENG-42",
+    title: "Test issue",
+    description: null,
+    priority: null,
+    state: "In Progress",
+    branchName: null,
+    url: null,
+    labels: [],
+    blockedBy: [],
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+interface CapturedEvent {
+  at: string;
+  issueId: string;
+  issueIdentifier: string;
+  sessionId: string | null;
+  event: string;
+  message: string;
+  usage?: unknown;
+  usageMode?: string;
+  content?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+describe("handleNotification", () => {
+  let state: TurnState;
+  let events: CapturedEvent[];
+  let onEvent: (event: CapturedEvent) => void;
+  const issue = makeIssue();
+
+  beforeEach(() => {
+    state = createTurnState();
+    events = [];
+    onEvent = (event) => events.push(event);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_ISO));
+  });
+
+  describe("turn/started", () => {
+    it("emits turn_started with the turn id from params", () => {
+      handleNotification({
+        state,
+        notification: { method: "turn/started", params: { turn: { id: "turn-abc" } } },
+        issue,
+        threadId: "thread-1",
+        turnId: "turn-old",
+        onEvent,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        at: FIXED_ISO,
+        issueId: "issue-1",
+        issueIdentifier: "ENG-42",
+        sessionId: "thread-1-turn-abc",
+        event: "turn_started",
+        message: "turn turn-abc started",
+      });
+    });
+
+    it("falls back to turnId when turn.id is absent", () => {
+      handleNotification({
+        state,
+        notification: { method: "turn/started", params: { turn: {} } },
+        issue,
+        threadId: "thread-1",
+        turnId: "turn-fallback",
+        onEvent,
+      });
+
+      expect(events[0]).toMatchObject({
+        sessionId: "thread-1-turn-fallback",
+        message: "turn started",
+      });
+    });
+  });
+
+  describe("turn/completed", () => {
+    it("records a completed turn in state", () => {
+      const resolver = vi.fn();
+      state.turnCompletionResolvers.set("turn-done", resolver);
+
+      handleNotification({
+        state,
+        notification: { method: "turn/completed", params: { turn: { id: "turn-done" } } },
+        issue,
+        threadId: "thread-1",
+        turnId: "turn-done",
+        onEvent,
+      });
+
+      expect(resolver).toHaveBeenCalled();
+      expect(events).toHaveLength(0);
+    });
+
+    it("buffers turn completion when no resolver is waiting", () => {
+      handleNotification({
+        state,
+        notification: { method: "turn/completed", params: { turn: { id: "turn-later" } } },
+        issue,
+        threadId: "thread-1",
+        turnId: null,
+        onEvent,
+      });
+
+      expect(state.completedTurnNotifications.has("turn-later")).toBe(true);
+    });
+  });
+
+  describe("thread/tokenUsage/updated", () => {
+    it("emits token_usage_updated with snapshot from total", () => {
+      handleNotification({
+        state,
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            turnId: "turn-tok",
+            tokenUsage: {
+              total: { inputTokens: 100, outputTokens: 200, totalTokens: 300 },
+            },
+          },
+        },
+        issue,
+        threadId: "thread-1",
+        turnId: null,
+        onEvent,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        event: "token_usage_updated",
+        sessionId: "thread-1-turn-tok",
+        usage: { inputTokens: 100, outputTokens: 200, totalTokens: 300 },
+        usageMode: "absolute_total",
+      });
+    });
+
+    it("is a no-op when total is missing valid token fields", () => {
+      handleNotification({
+        state,
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: { turnId: "t", tokenUsage: { total: { inputTokens: "bad" } } },
+        },
+        issue,
+        threadId: null,
+        turnId: null,
+        onEvent,
+      });
+
+      expect(events).toHaveLength(0);
+    });
+
+    it("falls back to turnId when params.turnId is absent", () => {
+      handleNotification({
+        state,
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: { tokenUsage: { total: { inputTokens: 1, outputTokens: 2, totalTokens: 3 } } },
+        },
+        issue,
+        threadId: "thread-1",
+        turnId: "fallback-turn",
+        onEvent,
+      });
+
+      expect(events[0]).toMatchObject({
+        sessionId: "thread-1-fallback-turn",
+        message: "token usage updated",
+      });
+    });
+  });
+
+  describe("item/reasoning/summaryTextDelta", () => {
+    it("appends reasoning text to the buffer by delta.id", () => {
+      handleNotification({
+        state,
+        notification: {
+          method: "item/reasoning/summaryTextDelta",
+          params: { delta: { id: "r-1", text: "thinking" } },
+        },
+        issue,
+        threadId: null,
+        turnId: null,
+        onEvent,
+      });
+
+      expect(state.reasoningBuffers.get("r-1")).toBe("thinking");
+    });
+
+    it("falls back to params.itemId when delta.id is absent", () => {
+      handleNotification({
+        state,
+        notification: {
+          method: "item/reasoning/textDelta",
+          params: { itemId: "r-2", delta: { text: "more" } },
+        },
+        issue,
+        threadId: null,
+        turnId: null,
+        onEvent,
+      });
+
+      expect(state.reasoningBuffers.get("r-2")).toBe("more");
+    });
+  });
+
+  describe("item/reasoning/summaryPartAdded", () => {
+    it("appends reasoning text from part.text", () => {
+      handleNotification({
+        state,
+        notification: {
+          method: "item/reasoning/summaryPartAdded",
+          params: { itemId: "r-3", part: { text: "summary chunk" } },
+        },
+        issue,
+        threadId: null,
+        turnId: null,
+        onEvent,
+      });
+
+      expect(state.reasoningBuffers.get("r-3")).toBe("summary chunk");
+    });
+  });
+
+  describe("item/started", () => {
+    it("emits an event with item type and id", () => {
+      handleNotification({
+        state,
+        notification: {
+          method: "item/started",
+          params: { item: { type: "commandExecution", id: "cmd-1", command: "ls -la" } },
+        },
+        issue,
+        threadId: "thread-1",
+        turnId: "turn-1",
+        onEvent,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        event: "item_started",
+        message: "commandExecution cmd-1 started",
+        content: "ls -la",
+      });
+    });
+  });
+
+  describe("item/completed", () => {
+    it("emits an event and clears reasoning buffer", () => {
+      state.reasoningBuffers.set("reason-item", "accumulated reasoning");
+
+      handleNotification({
+        state,
+        notification: {
+          method: "item/completed",
+          params: { item: { type: "reasoning", id: "reason-item" } },
+        },
+        issue,
+        threadId: "thread-1",
+        turnId: "turn-1",
+        onEvent,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        event: "item_completed",
+        message: "reasoning reason-item completed",
+        content: "accumulated reasoning",
+      });
+      expect(state.reasoningBuffers.has("reason-item")).toBe(false);
+    });
+
+    it("uses 'item' as fallback type when item.type is absent", () => {
+      handleNotification({
+        state,
+        notification: {
+          method: "item/completed",
+          params: { item: {} },
+        },
+        issue,
+        threadId: null,
+        turnId: null,
+        onEvent,
+      });
+
+      expect(events[0]).toMatchObject({
+        message: "item completed",
+      });
+    });
+  });
+
+  describe("codex notification mapping", () => {
+    it.each([
+      ["codex/event/task_started", "agent_started", "Agent started working"],
+      ["codex/event/task_complete", "agent_complete", "Agent completed work"],
+      ["codex/event/item_started", "step_started", "Agent began a step"],
+      ["codex/event/item_completed", "step_completed", "Agent finished a step"],
+      ["codex/event/agent_message", "agent_message", "Agent sent a message"],
+      ["codex/event/agent_message_delta", "agent_streaming", "Agent streaming text"],
+      ["codex/event/agent_message_content_delta", "agent_streaming", "Agent streaming text"],
+      ["codex/event/token_count", "token_usage", "Token usage updated"],
+      ["codex/event/turn_diff", "turn_diff", "Turn diff computed"],
+      ["codex/event/exec_command_begin", "tool_exec", "Running shell command"],
+      ["codex/event/exec_command_end", "tool_exec", "Shell command finished"],
+      ["codex/event/exec_command_output_delta", "tool_output", "Command output streaming"],
+      ["codex/event/patch_apply_begin", "tool_edit", "Applying file changes"],
+      ["codex/event/patch_apply_end", "tool_edit", "File changes applied"],
+      ["codex/event/mcp_startup_complete", "system", "MCP tools initialized"],
+      ["thread/started", "thread_started", "Thread session opened"],
+      ["thread/status/changed", "thread_status", "Thread status changed"],
+      ["account/rateLimits/updated", "rate_limits", "API rate limits updated"],
+      ["item/agentMessage/delta", "agent_streaming", "Agent streaming text"],
+      ["item/fileChange/outputDelta", "tool_output", "File change output streaming"],
+    ])("maps %s to event=%s, message=%s", (method, expectedEvent, expectedMessage) => {
+      handleNotification({
+        state,
+        notification: { method, params: {} },
+        issue,
+        threadId: null,
+        turnId: null,
+        onEvent,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        event: expectedEvent,
+        message: expectedMessage,
+      });
+    });
+  });
+
+  describe("fallback for unknown methods", () => {
+    it("uses params.message when available", () => {
+      handleNotification({
+        state,
+        notification: { method: "some/unknown/method", params: { message: "custom output" } },
+        issue,
+        threadId: null,
+        turnId: null,
+        onEvent,
+      });
+
+      expect(events[0]).toMatchObject({
+        event: "agent_output",
+        message: "custom output",
+      });
+    });
+
+    it("uses params.text as second fallback", () => {
+      handleNotification({
+        state,
+        notification: { method: "some/unknown/method", params: { text: "text output" } },
+        issue,
+        threadId: null,
+        turnId: null,
+        onEvent,
+      });
+
+      expect(events[0]).toMatchObject({
+        event: "agent_output",
+        message: "text output",
+      });
+    });
+
+    it("uses params.description as third fallback", () => {
+      handleNotification({
+        state,
+        notification: { method: "some/unknown/method", params: { description: "desc output" } },
+        issue,
+        threadId: null,
+        turnId: null,
+        onEvent,
+      });
+
+      expect(events[0]).toMatchObject({
+        event: "agent_output",
+        message: "desc output",
+      });
+    });
+
+    it("returns method as event=other when no message fields exist", () => {
+      handleNotification({
+        state,
+        notification: { method: "completely/unknown", params: {} },
+        issue,
+        threadId: null,
+        turnId: null,
+        onEvent,
+      });
+
+      expect(events[0]).toMatchObject({
+        event: "other",
+        message: "completely/unknown",
+      });
+    });
+
+    it("handles missing params gracefully", () => {
+      handleNotification({
+        state,
+        notification: { method: "no/params" },
+        issue,
+        threadId: null,
+        turnId: null,
+        onEvent,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        event: "other",
+        message: "no/params",
+      });
+    });
+  });
+});

--- a/tests/agent-runner/session-init.test.ts
+++ b/tests/agent-runner/session-init.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter, Readable } from "node:stream";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+
+import { initializeSession } from "../../src/agent-runner/session-init.js";
+import { StartupTimeoutError } from "../../src/agent-runner/session-helpers.js";
+import { createMockLogger } from "../helpers.js";
+import type { DockerSession } from "../../src/agent-runner/docker-session.js";
+import type { Issue, ModelSelection, ServiceConfig, Workspace } from "../../src/core/types.js";
+
+function makeIssue(overrides?: Partial<Issue>): Issue {
+  return {
+    id: "issue-1",
+    identifier: "ENG-42",
+    title: "Test issue",
+    description: null,
+    priority: null,
+    state: "In Progress",
+    branchName: null,
+    url: null,
+    labels: [],
+    blockedBy: [],
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+function makeWorkspace(overrides?: Partial<Workspace>): Workspace {
+  return {
+    path: "/workspace/test",
+    workspaceKey: "test-key",
+    createdNow: false,
+    ...overrides,
+  };
+}
+
+function makeModelSelection(overrides?: Partial<ModelSelection>): ModelSelection {
+  return {
+    model: "o3",
+    reasoningEffort: null,
+    source: "default",
+    ...overrides,
+  };
+}
+
+function makeMinimalConfig(): ServiceConfig {
+  return {
+    codex: {
+      approvalPolicy: "auto-edit",
+      threadSandbox: "none",
+    },
+  } as unknown as ServiceConfig;
+}
+
+interface CapturedEvent {
+  event: string;
+  message: string;
+  [key: string]: unknown;
+}
+
+interface MockConnection {
+  request: ReturnType<typeof vi.fn>;
+  notify: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Creates a fake ChildProcess whose stdout emits data on the next tick,
+ * satisfying waitForStartup without needing to mock the module.
+ */
+function makeFakeChild(): ChildProcessWithoutNullStreams {
+  const stdout = new Readable({ read() {} });
+  const stderr = new Readable({ read() {} });
+  const child = new EventEmitter() as unknown as ChildProcessWithoutNullStreams;
+  (child as unknown as Record<string, unknown>).stdout = stdout;
+  (child as unknown as Record<string, unknown>).stderr = stderr;
+  // Emit data on next tick so waitForStartup resolves immediately
+  queueMicrotask(() => stdout.push("ready"));
+  return child;
+}
+
+/**
+ * Creates a fake ChildProcess that never emits data, causing
+ * waitForStartup to time out.
+ */
+function makeSilentChild(): ChildProcessWithoutNullStreams {
+  const stdout = new Readable({ read() {} });
+  const stderr = new Readable({ read() {} });
+  const child = new EventEmitter() as unknown as ChildProcessWithoutNullStreams;
+  (child as unknown as Record<string, unknown>).stdout = stdout;
+  (child as unknown as Record<string, unknown>).stderr = stderr;
+  return child;
+}
+
+function makeMockSession(overrides?: {
+  inspectRunning?: () => Promise<boolean | null>;
+  connection?: Partial<MockConnection>;
+  child?: ChildProcessWithoutNullStreams;
+}): DockerSession & { connection: MockConnection } {
+  const connection: MockConnection = {
+    request: vi.fn().mockResolvedValue({}),
+    notify: vi.fn(),
+    ...overrides?.connection,
+  };
+
+  return {
+    child: overrides?.child ?? makeFakeChild(),
+    connection: connection as unknown as DockerSession["connection"],
+    containerName: "test-container",
+    threadId: null,
+    turnId: null,
+    exitPromise: new Promise(() => {}),
+    getFatalFailure: () => null,
+    inspectRunning: overrides?.inspectRunning ?? (async () => true),
+    cleanup: vi.fn(),
+  } as unknown as DockerSession & { connection: MockConnection };
+}
+
+function makeLiquid(overrides?: { parse?: () => unknown; render?: () => Promise<string> }) {
+  return {
+    parse: overrides?.parse ?? (() => []),
+    render: overrides?.render ?? (async () => "rendered prompt"),
+  } as unknown as import("liquidjs").Liquid;
+}
+
+describe("initializeSession", () => {
+  let events: CapturedEvent[];
+  let onEvent: (event: CapturedEvent) => void;
+  const logger = createMockLogger();
+  const deps = { logger };
+
+  beforeEach(() => {
+    events = [];
+    onEvent = (event) => events.push(event);
+  });
+
+  function makeInput(overrides?: Record<string, unknown>) {
+    return {
+      issue: makeIssue(),
+      attempt: 1,
+      modelSelection: makeModelSelection(),
+      workspace: makeWorkspace(),
+      promptTemplate: "Fix {{ issue.identifier }}",
+      signal: new AbortController().signal,
+      onEvent,
+      startupTimeoutMs: 5000,
+      ...overrides,
+    };
+  }
+
+  describe("happy path", () => {
+    it("returns threadId and rendered prompt on success", async () => {
+      const session = makeMockSession();
+      session.connection.request
+        .mockResolvedValueOnce({}) // initialize
+        .mockResolvedValueOnce({ status: "authenticated" }) // account/read
+        .mockResolvedValueOnce({ rateLimits: [] }) // account/rateLimits/read
+        .mockResolvedValueOnce({ threadId: "thread-abc" }); // thread/start
+
+      const input = makeInput();
+      const liquid = makeLiquid({ render: async () => "Fix ENG-42" });
+
+      const result = await initializeSession(session, makeMinimalConfig(), input, deps, liquid);
+
+      expect(result).toEqual({ threadId: "thread-abc", prompt: "Fix ENG-42" });
+      expect(session.threadId).toBe("thread-abc");
+    });
+  });
+
+  describe("startup timeout", () => {
+    it("re-throws StartupTimeoutError after emitting container_startup_timeout", async () => {
+      vi.useFakeTimers();
+      const session = makeMockSession({ child: makeSilentChild() });
+      const input = makeInput({ startupTimeoutMs: 100 });
+      const liquid = makeLiquid();
+
+      const promise = initializeSession(session, makeMinimalConfig(), input, deps, liquid);
+      vi.advanceTimersByTime(101);
+
+      await expect(promise).rejects.toThrow(StartupTimeoutError);
+
+      const timeoutEvent = events.find((e) => e.event === "container_startup_timeout");
+      expect(timeoutEvent).toBeDefined();
+      expect(timeoutEvent!.message).toContain("100ms");
+
+      vi.useRealTimers();
+    });
+
+    it("re-throws non-timeout startup errors without emitting timeout event", async () => {
+      const child = makeSilentChild();
+      const session = makeMockSession({ child });
+      const input = makeInput();
+      const liquid = makeLiquid();
+
+      const promise = initializeSession(session, makeMinimalConfig(), input, deps, liquid);
+      // Simulate child exit before startup readiness
+      child.emit("exit", 1);
+
+      await expect(promise).rejects.toThrow("child exited with code 1 before startup readiness");
+
+      const timeoutEvent = events.find((e) => e.event === "container_startup_timeout");
+      expect(timeoutEvent).toBeUndefined();
+    });
+  });
+
+  describe("container not running", () => {
+    it("returns failed outcome with container_start_failed when inspectRunning returns false", async () => {
+      const session = makeMockSession({ inspectRunning: async () => false });
+      const input = makeInput();
+      const liquid = makeLiquid();
+
+      const result = await initializeSession(session, makeMinimalConfig(), input, deps, liquid);
+
+      expect(result).toMatchObject({
+        kind: "failed",
+        errorCode: "container_start_failed",
+        errorMessage: "sandbox container failed to reach a running state",
+        threadId: null,
+        turnId: null,
+        turnCount: 0,
+      });
+    });
+
+    it("returns failed outcome with container_start_failed when inspectRunning throws", async () => {
+      const session = makeMockSession({
+        inspectRunning: async () => {
+          throw new Error("docker inspect failed");
+        },
+      });
+      const input = makeInput();
+      const liquid = makeLiquid();
+
+      const result = await initializeSession(session, makeMinimalConfig(), input, deps, liquid);
+
+      expect(result).toMatchObject({
+        kind: "failed",
+        errorCode: "container_start_failed",
+        errorMessage: "docker inspect failed",
+        threadId: null,
+        turnId: null,
+        turnCount: 0,
+      });
+    });
+  });
+
+  describe("auth failure", () => {
+    it("returns startup_failed when auth is required but no account is present", async () => {
+      const session = makeMockSession();
+      session.connection.request
+        .mockResolvedValueOnce({}) // initialize
+        .mockResolvedValueOnce({ authRequired: true }); // account/read
+
+      const input = makeInput();
+      const liquid = makeLiquid();
+
+      const result = await initializeSession(session, makeMinimalConfig(), input, deps, liquid);
+
+      expect(result).toMatchObject({
+        kind: "failed",
+        errorCode: "startup_failed",
+        errorMessage: expect.stringContaining("OpenAI auth is required"),
+        threadId: null,
+        turnId: null,
+        turnCount: 0,
+      });
+    });
+  });
+
+  describe("template parse error", () => {
+    it("returns template_parse_error when liquid.parse throws", async () => {
+      const session = makeMockSession();
+      session.connection.request
+        .mockResolvedValueOnce({}) // initialize
+        .mockResolvedValueOnce({ status: "authenticated" }) // account/read
+        .mockResolvedValueOnce({}) // account/rateLimits/read
+        .mockResolvedValueOnce({ threadId: "thread-1" }); // thread/start
+
+      const liquid = makeLiquid({
+        parse: () => {
+          throw new Error("unexpected tag");
+        },
+      });
+
+      const input = makeInput();
+      const result = await initializeSession(session, makeMinimalConfig(), input, deps, liquid);
+
+      expect(result).toMatchObject({
+        kind: "failed",
+        errorCode: "template_parse_error",
+        errorMessage: "unexpected tag",
+        threadId: "thread-1",
+        turnId: null,
+        turnCount: 0,
+      });
+    });
+  });
+
+  describe("template render error", () => {
+    it("returns template_render_error when liquid.render throws", async () => {
+      const session = makeMockSession();
+      session.connection.request
+        .mockResolvedValueOnce({}) // initialize
+        .mockResolvedValueOnce({ status: "authenticated" }) // account/read
+        .mockResolvedValueOnce({}) // account/rateLimits/read
+        .mockResolvedValueOnce({ threadId: "thread-2" }); // thread/start
+
+      const liquid = makeLiquid({
+        render: async () => {
+          throw new Error("undefined variable: missing");
+        },
+      });
+
+      const input = makeInput();
+      const result = await initializeSession(session, makeMinimalConfig(), input, deps, liquid);
+
+      expect(result).toMatchObject({
+        kind: "failed",
+        errorCode: "template_render_error",
+        errorMessage: "undefined variable: missing",
+        threadId: "thread-2",
+        turnId: null,
+        turnCount: 0,
+      });
+    });
+  });
+
+  describe("rate limit preflight", () => {
+    it("continues normally when rate limit read fails", async () => {
+      const session = makeMockSession();
+      session.connection.request
+        .mockResolvedValueOnce({}) // initialize
+        .mockResolvedValueOnce({ status: "authenticated" }) // account/read
+        .mockRejectedValueOnce(new Error("rate limit unavailable")) // account/rateLimits/read
+        .mockResolvedValueOnce({ threadId: "thread-3" }); // thread/start
+
+      const liquid = makeLiquid({ render: async () => "prompt" });
+      const input = makeInput();
+
+      const result = await initializeSession(session, makeMinimalConfig(), input, deps, liquid);
+
+      expect(result).toEqual({ threadId: "thread-3", prompt: "prompt" });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.stringContaining("rate limit unavailable") }),
+        "rate limit preflight unavailable",
+      );
+    });
+  });
+
+  describe("thread/start failure", () => {
+    it("throws when thread/start returns no thread identifier", async () => {
+      const session = makeMockSession();
+      session.connection.request
+        .mockResolvedValueOnce({}) // initialize
+        .mockResolvedValueOnce({ status: "authenticated" }) // account/read
+        .mockResolvedValueOnce({}) // account/rateLimits/read
+        .mockResolvedValueOnce({}); // thread/start -- no threadId
+
+      const liquid = makeLiquid();
+      const input = makeInput();
+
+      await expect(initializeSession(session, makeMinimalConfig(), input, deps, liquid)).rejects.toThrow(
+        "thread/start did not return a thread identifier",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 38 unit tests for `src/agent-runner/notification-handler.ts` covering all method handlers (turn/started, turn/completed, token usage, reasoning delta/part, item started/completed), all 19 codex notification mappings, and unknown method fallbacks.
- Add 10 unit tests for `src/agent-runner/session-init.ts` covering the happy path, startup timeout, container-not-running (2 modes), auth failure, template parse/render errors, rate limit preflight failure, and thread/start failure.
- Uses fake `ChildProcess` streams (matching `session-helpers.test.ts` patterns) instead of `vi.mock` to avoid mock leakage across test files in the same vitest fork.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (warnings only, pre-existing)
- [x] `npm run format:check` passes
- [x] `npm test` passes (all 104 files, 920 tests + 2 skipped)
- [x] No regressions in existing `agent-runner.test.ts` integration tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
