### PR TITLE
fix(setup): correct repo route deletion to use HTTP DELETE

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -119,9 +119,8 @@ export const api = {
     post<{ ok: boolean; route: Record<string, unknown> }>("/api/v1/setup/repo-route", route),
   getRepoRoutes: () => get<{ routes: Array<Record<string, unknown>> }>("/api/v1/setup/repo-routes"),
   deleteRepoRoute: (index: number) =>
-    post<{ ok: boolean; routes: Array<Record<string, unknown>> }>("/api/v1/setup/repo-route", {
+    send<{ ok: boolean; routes: Array<Record<string, unknown>> }>("DELETE", "/api/v1/setup/repo-route", {
       index,
-      _method: "DELETE",
     }),
   resetSetup: () => post<{ ok: boolean }>("/api/v1/setup/reset", {}),
   createTestIssue: () =>


### PR DESCRIPTION
## Summary

- The frontend's `deleteRepoRoute` was sending a POST request with `_method: "DELETE"` in the body, but Express does not honor method overrides by default. The server registers an actual `.delete()` handler on `/api/v1/setup/repo-route`, so the POST never reached it -- repo routes could not be deleted from the UI.
- Switched to sending a real HTTP DELETE request via the existing `send()` helper, matching the server's route registration.

## Test plan

- [x] Existing unit tests for `handleDeleteRepoRoute` pass (tests send actual DELETE requests)
- [x] Full test suite: 129 files, 1385 tests passing
- [x] Build, lint, and format checks clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
