### PR TITLE
docs: sync version references to 0.4.0 and fix trust claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <img alt="Node.js" src="https://img.shields.io/badge/node-%3E%3D22-brightgreen?style=flat-square&logo=node.js" />
   <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-strict-blue?style=flat-square&logo=typescript" />
   <img alt="Docker" src="https://img.shields.io/badge/Docker-ready-2496ED?style=flat-square&logo=docker" />
-  <img alt="Status" src="https://img.shields.io/badge/status-v0.3.1-orange?style=flat-square" />
+  <img alt="Status" src="https://img.shields.io/badge/status-v0.4.0-orange?style=flat-square" />
 </p>
 
 <br/>
@@ -46,7 +46,7 @@ Symphony is a **local orchestration engine** that watches your project tracker f
 You create an issue  →  Symphony picks it up  →  AI agent writes code  →  PR lands on GitHub
 ```
 
-**No cloud service. No SaaS. No data leaves your machine.** Symphony runs entirely on your local machine or a VDS you control, connecting your existing Linear project to AI-powered Codex agents running inside isolated Docker containers.
+**No cloud service. No SaaS. Your code stays on your machine.** Symphony runs on your local machine or a VDS you control, connecting your existing Linear project to AI-powered Codex agents running inside isolated Docker containers. It communicates with configured external services (Linear, model providers) via their APIs, but your source code and workspace data never leave your infrastructure.
 
 ---
 
@@ -133,7 +133,7 @@ codex login                       # ChatGPT/Codex subscription path
 
 ---
 
-## ✨ What Ships Today (v0.3.1)
+## ✨ What Ships Today (v0.4.0)
 
 <table>
 <tr>

--- a/docs/CONFORMANCE_AUDIT.md
+++ b/docs/CONFORMANCE_AUDIT.md
@@ -3,7 +3,7 @@
 > Per-requirement spec conformance audit for Symphony Orchestrator.
 
 <p>
-  <img alt="Version" src="https://img.shields.io/badge/version-0.3.1-blue?style=flat-square" />
+  <img alt="Version" src="https://img.shields.io/badge/version-0.4.0-blue?style=flat-square" />
   <img alt="Status" src="https://img.shields.io/badge/status-shipped-brightgreen?style=flat-square" />
 </p>
 
@@ -11,7 +11,7 @@
 
 ## 📌 Current Release Baseline
 
-The repository is at **`v0.3.1`** and implements a full local orchestration loop for Linear-driven Codex work with git automation, secrets management, notifications, and a Docker deployment target. This document tracks every atomic requirement from the Symphony Service Specification against the current codebase.
+The repository is at **`v0.4.0`** and implements a full local orchestration loop for Linear-driven Codex work with git automation, secrets management, notifications, and a Docker deployment target. This document tracks every atomic requirement from the Symphony Service Specification against the current codebase.
 
 **Legend:** ✅ Implemented · 🟡 Partial / Minor Deviation · ❌ Not Implemented · 🔵 Extension (beyond spec)
 
@@ -681,7 +681,7 @@ Capabilities shipped that go beyond the spec requirements:
 | Error tracking           | Sentry-ready error tracker with breadcrumbs and context                                           |
 | Developer tooling        | ESLint, Prettier, husky, knip, jscpd, TypeDoc                                                     |
 
-### Resilience Extensions (v0.3.1)
+### Resilience Extensions (v0.4.0)
 
 | Extension                     | Description                                                                                                                                         |
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

- Updated all stale `v0.3.1` version references to `v0.4.0` in `README.md` (status badge, "What Ships Today" heading) and `docs/CONFORMANCE_AUDIT.md` (version badge, baseline statement, resilience extensions heading)
- Replaced misleading "No data leaves your machine" claim in README.md with accurate language acknowledging external API communication (Linear, model providers) while clarifying source code stays on operator infrastructure, consistent with `docs/TRUST_AND_AUTH.md`
- Historical "Shipped in v0.3.1" references in `docs/ROADMAP_AND_STATUS.md` left untouched -- they correctly describe when features shipped

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes (pre-existing warnings only)
- [x] `pnpm run format:check` passes
- [x] `pnpm test` passes (1385 tests, 0 failures)
- [x] No `.md` files contain stale current-version references to `0.3.1`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
