### PR TITLE
fix(setup): preserve custom provider config when saving OpenAI key

### DIFF
--- a/src/setup/setup-handlers.ts
+++ b/src/setup/setup-handlers.ts
@@ -181,14 +181,26 @@ export function handlePostOpenaiKey(deps: SetupApiDeps) {
     }
 
     if (valid) {
-      await Promise.all([
+      const overlay = deps.configOverlayStore.toMap();
+      const codex = isRecord(overlay.codex) ? overlay.codex : undefined;
+      const provider = isRecord(codex?.provider) ? codex.provider : undefined;
+      const hasCustomProvider = !!provider?.name;
+
+      const operations: Promise<unknown>[] = [
         deps.secretsStore.set("OPENAI_API_KEY", key),
         deps.configOverlayStore.set("codex.auth.mode", "api_key"),
-        deps.configOverlayStore.set("codex.provider.name", "CLIProxyAPI"),
-        deps.configOverlayStore.set("codex.provider.base_url", "http://localhost:8317/v1"),
-        deps.configOverlayStore.set("codex.provider.env_key", "OPENAI_API_KEY"),
-        deps.configOverlayStore.set("codex.provider.wire_api", "responses"),
-      ]);
+      ];
+
+      if (!hasCustomProvider) {
+        operations.push(
+          deps.configOverlayStore.set("codex.provider.name", "CLIProxyAPI"),
+          deps.configOverlayStore.set("codex.provider.base_url", "http://localhost:8317/v1"),
+          deps.configOverlayStore.set("codex.provider.env_key", "OPENAI_API_KEY"),
+          deps.configOverlayStore.set("codex.provider.wire_api", "responses"),
+        );
+      }
+
+      await Promise.all(operations);
     }
 
     res.json({ valid });

--- a/tests/setup/api.test.ts
+++ b/tests/setup/api.test.ts
@@ -284,11 +284,12 @@ describe("registerSetupApi", () => {
     });
   });
 
-  it("validates and stores a valid OpenAI key", async () => {
+  it("validates and stores a valid OpenAI key with CLIProxyAPI provider when no provider exists", async () => {
     const secretsStore = createSecretsStoreMock();
+    const configOverlayStore = createConfigOverlayStoreMock();
     getExternalFetchMock().mockResolvedValueOnce(textResponse(200, "ok"));
 
-    const { baseUrl } = await startSetupApiServer({ secretsStore });
+    const { baseUrl } = await startSetupApiServer({ secretsStore, configOverlayStore });
     const response = await postJson(baseUrl, "/api/v1/setup/openai-key", { key: "sk-valid" });
 
     expect(response.status).toBe(200);
@@ -297,6 +298,39 @@ describe("registerSetupApi", () => {
       headers: { authorization: "Bearer sk-valid" },
     });
     expect(secretsStore.set).toHaveBeenCalledWith("OPENAI_API_KEY", "sk-valid");
+    expect(configOverlayStore.set).toHaveBeenCalledWith("codex.auth.mode", "api_key");
+    expect(configOverlayStore.set).toHaveBeenCalledWith("codex.provider.name", "CLIProxyAPI");
+    expect(configOverlayStore.set).toHaveBeenCalledWith("codex.provider.base_url", "http://localhost:8317/v1");
+    expect(configOverlayStore.set).toHaveBeenCalledWith("codex.provider.env_key", "OPENAI_API_KEY");
+    expect(configOverlayStore.set).toHaveBeenCalledWith("codex.provider.wire_api", "responses");
+  });
+
+  it("preserves custom provider config when saving a valid OpenAI key", async () => {
+    const secretsStore = createSecretsStoreMock();
+    const configOverlayStore = createConfigOverlayStoreMock();
+    vi.spyOn(configOverlayStore, "toMap").mockReturnValue({
+      codex: {
+        provider: {
+          name: "MyCustomProvider",
+          base_url: "https://custom-llm.example.com/v1",
+          env_key: "CUSTOM_API_KEY",
+          wire_api: "chat",
+        },
+      },
+    });
+    getExternalFetchMock().mockResolvedValueOnce(textResponse(200, "ok"));
+
+    const { baseUrl } = await startSetupApiServer({ secretsStore, configOverlayStore });
+    const response = await postJson(baseUrl, "/api/v1/setup/openai-key", { key: "sk-valid" });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ valid: true });
+    expect(secretsStore.set).toHaveBeenCalledWith("OPENAI_API_KEY", "sk-valid");
+    expect(configOverlayStore.set).toHaveBeenCalledWith("codex.auth.mode", "api_key");
+    expect(configOverlayStore.set).not.toHaveBeenCalledWith("codex.provider.name", expect.anything());
+    expect(configOverlayStore.set).not.toHaveBeenCalledWith("codex.provider.base_url", expect.anything());
+    expect(configOverlayStore.set).not.toHaveBeenCalledWith("codex.provider.env_key", expect.anything());
+    expect(configOverlayStore.set).not.toHaveBeenCalledWith("codex.provider.wire_api", expect.anything());
   });
 
   it("rejects an invalid OpenAI key", async () => {


### PR DESCRIPTION
## Summary

- `handlePostOpenaiKey` previously hardcoded CLIProxyAPI provider fields (`name`, `base_url`, `env_key`, `wire_api`) on every OpenAI key save, overwriting any custom provider the operator had configured in the config overlay.
- Now checks for an existing `codex.provider.name` in the overlay before applying CLIProxyAPI defaults. If the operator has explicitly configured a custom provider, it is preserved.
- Fresh setups (no provider configured) continue to get CLIProxyAPI defaults as before.

## Test plan

- [x] Existing test updated to verify CLIProxyAPI provider fields are set when no provider exists
- [x] New test added: verifies custom provider config is NOT overwritten when saving a valid OpenAI key
- [x] Full CI gate passes: `pnpm run build && pnpm run lint && pnpm run format:check && pnpm test` (129 test files, 1386 tests)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
