### PR TITLE
refactor(dispatch): extract runner and tracker factory modules

### DIFF
--- a/src/cli/services.ts
+++ b/src/cli/services.ts
@@ -1,21 +1,17 @@
-import { AgentRunner } from "../agent-runner/index.js";
 import { AttemptStore } from "../core/attempt-store.js";
 import { TypedEventBus } from "../core/event-bus.js";
 import type { SymphonyEventMap } from "../core/symphony-events.js";
 import { createGitHubToolProvider, createRepoRouterProvider } from "./runtime-providers.js";
 import type { ConfigOverlayStore } from "../config/overlay.js";
 import type { ConfigStore } from "../config/store.js";
-import { DispatchClient } from "../dispatch/client.js";
-import type { RunAttemptDispatcher } from "../dispatch/types.js";
+import { createDispatcher } from "../dispatch/factory.js";
 import { HttpServer } from "../http/server.js";
-import { LinearClient } from "../linear/client.js";
-import { LinearTrackerAdapter } from "../tracker/linear-adapter.js";
 import type { createLogger } from "../core/logger.js";
 import { NotificationManager } from "../notification/manager.js";
 import { Orchestrator } from "../orchestrator/orchestrator.js";
 import { PathRegistry } from "../workspace/path-registry.js";
-
 import type { SecretsStore } from "../secrets/store.js";
+import { createTracker } from "../tracker/factory.js";
 import { WorkspaceManager } from "../workspace/manager.js";
 
 export async function createServices(
@@ -29,10 +25,18 @@ export async function createServices(
   if (persistedGithubToken) {
     process.env.GITHUB_TOKEN = persistedGithubToken;
   }
+
   const attemptStore = new AttemptStore(archiveDir, logger.child({ component: "attempt-store" }));
   await attemptStore.start();
-  const linearClient = new LinearClient(() => configStore.getConfig(), logger.child({ component: "linear" }));
-  const tracker = new LinearTrackerAdapter(linearClient);
+
+  const { tracker, linearClient } = createTracker(() => configStore.getConfig(), logger);
+
+  const repoRouter = createRepoRouterProvider(() => configStore.getConfig());
+  const gitManager = createGitHubToolProvider(() => configStore.getConfig(), {
+    env: process.env,
+    resolveSecret: (name) => secretsStore.get(name) ?? undefined,
+  });
+
   const workspaceManager = new WorkspaceManager(
     () => configStore.getConfig(),
     logger.child({ component: "workspace" }),
@@ -49,36 +53,20 @@ export async function createServices(
       },
     },
   );
-  const notificationManager = new NotificationManager({ logger: logger.child({ component: "notifications" }) });
+
   const pathRegistry = PathRegistry.fromEnv();
-  const repoRouter = createRepoRouterProvider(() => configStore.getConfig());
-  const gitManager = createGitHubToolProvider(() => configStore.getConfig(), {
-    env: process.env,
-    resolveSecret: (name) => secretsStore.get(name) ?? undefined,
+  const agentRunner = createDispatcher(() => configStore.getConfig(), {
+    tracker,
+    linearClient,
+    workspaceManager,
+    archiveDir,
+    pathRegistry,
+    githubToolClient: gitManager,
+    logger,
   });
 
-  // Dispatch mode: remote (data plane) or local (in-process)
-  const dispatchMode = process.env.DISPATCH_MODE ?? "local";
-  const agentRunner: RunAttemptDispatcher =
-    dispatchMode === "remote"
-      ? new DispatchClient({
-          dispatchUrl: process.env.DISPATCH_URL ?? "http://data-plane:9100/dispatch", // NOSONAR — internal service-to-service on private network
-          secret: process.env.DISPATCH_SHARED_SECRET ?? "",
-          getConfig: () => configStore.getConfig(),
-          logger: logger.child({ component: "dispatch-client" }),
-        })
-      : new AgentRunner({
-          getConfig: () => configStore.getConfig(),
-          tracker,
-          linearClient,
-          workspaceManager,
-          archiveDir,
-          pathRegistry,
-          githubToolClient: gitManager,
-          logger: logger.child({ component: "agent-runner" }),
-        });
-
   const eventBus = new TypedEventBus<SymphonyEventMap>();
+  const notificationManager = new NotificationManager({ logger: logger.child({ component: "notifications" }) });
 
   const orchestrator = new Orchestrator({
     attemptStore,
@@ -92,6 +80,7 @@ export async function createServices(
     gitManager,
     logger: logger.child({ component: "orchestrator" }),
   });
+
   const httpServer = new HttpServer({
     orchestrator,
     logger: logger.child({ component: "http" }),
@@ -99,8 +88,8 @@ export async function createServices(
     configStore,
     configOverlayStore: overlayStore,
     secretsStore,
-
     archiveDir,
   });
+
   return { orchestrator, httpServer, notificationManager, linearClient };
 }

--- a/src/dispatch/factory.ts
+++ b/src/dispatch/factory.ts
@@ -1,0 +1,53 @@
+import { AgentRunner } from "../agent-runner/index.js";
+import type { GithubApiToolClient } from "../git/github-api-tool.js";
+import type { LinearClient } from "../linear/client.js";
+import type { TrackerPort } from "../tracker/port.js";
+import type { ServiceConfig, SymphonyLogger } from "../core/types.js";
+import type { PathRegistry } from "../workspace/path-registry.js";
+import type { WorkspaceManager } from "../workspace/manager.js";
+import { DispatchClient } from "./client.js";
+import type { RunAttemptDispatcher } from "./types.js";
+
+/**
+ * Dependencies the dispatcher factory needs to construct either a local
+ * AgentRunner or a remote DispatchClient.
+ */
+export interface DispatcherFactoryDeps {
+  tracker: TrackerPort;
+  linearClient: LinearClient;
+  workspaceManager: WorkspaceManager;
+  archiveDir: string;
+  pathRegistry: PathRegistry;
+  githubToolClient: GithubApiToolClient;
+  logger: SymphonyLogger;
+}
+
+/**
+ * Creates a {@link RunAttemptDispatcher} based on the `DISPATCH_MODE` env var.
+ *
+ * - `"local"` (default): in-process {@link AgentRunner}
+ * - `"remote"`: {@link DispatchClient} pointing at `DISPATCH_URL`
+ */
+export function createDispatcher(getConfig: () => ServiceConfig, deps: DispatcherFactoryDeps): RunAttemptDispatcher {
+  const dispatchMode = process.env.DISPATCH_MODE ?? "local";
+
+  if (dispatchMode === "remote") {
+    return new DispatchClient({
+      dispatchUrl: process.env.DISPATCH_URL ?? "http://data-plane:9100/dispatch", // NOSONAR — internal service-to-service on private network
+      secret: process.env.DISPATCH_SHARED_SECRET ?? "",
+      getConfig,
+      logger: deps.logger.child({ component: "dispatch-client" }),
+    });
+  }
+
+  return new AgentRunner({
+    getConfig,
+    tracker: deps.tracker,
+    linearClient: deps.linearClient,
+    workspaceManager: deps.workspaceManager,
+    archiveDir: deps.archiveDir,
+    pathRegistry: deps.pathRegistry,
+    githubToolClient: deps.githubToolClient,
+    logger: deps.logger.child({ component: "agent-runner" }),
+  });
+}

--- a/src/tracker/factory.ts
+++ b/src/tracker/factory.ts
@@ -1,0 +1,24 @@
+import type { ServiceConfig, SymphonyLogger } from "../core/types.js";
+import { LinearClient } from "../linear/client.js";
+import { LinearTrackerAdapter } from "./linear-adapter.js";
+import type { TrackerPort } from "./port.js";
+
+/**
+ * Result of tracker factory — exposes both the abstract port (for orchestration)
+ * and the concrete LinearClient (for MCP GraphQL tool / direct API calls).
+ */
+export interface TrackerFactoryResult {
+  tracker: TrackerPort;
+  linearClient: LinearClient;
+}
+
+/**
+ * Creates the tracker subsystem from service config.
+ * Encapsulates LinearClient instantiation and adapter wrapping so that
+ * `services.ts` does not depend on tracker internals.
+ */
+export function createTracker(getConfig: () => ServiceConfig, logger: SymphonyLogger): TrackerFactoryResult {
+  const linearClient = new LinearClient(getConfig, logger.child({ component: "linear" }));
+  const tracker = new LinearTrackerAdapter(linearClient);
+  return { tracker, linearClient };
+}

--- a/tests/dispatch/factory.test.ts
+++ b/tests/dispatch/factory.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createDispatcher } from "../../src/dispatch/factory.js";
+import { AgentRunner } from "../../src/agent-runner/index.js";
+import { DispatchClient } from "../../src/dispatch/client.js";
+import { createMockLogger } from "../helpers.js";
+import type { DispatcherFactoryDeps } from "../../src/dispatch/factory.js";
+import type { ServiceConfig } from "../../src/core/types.js";
+
+function createConfig(): ServiceConfig {
+  return {
+    tracker: {
+      kind: "linear",
+      apiKey: "linear-token",
+      endpoint: "https://api.linear.app/graphql",
+      projectSlug: "TEST",
+      activeStates: ["In Progress"],
+      terminalStates: ["Done"],
+    },
+    polling: { intervalMs: 1000 },
+    workspace: {
+      root: "/tmp/symphony",
+      strategy: "directory",
+      branchPrefix: "symphony/",
+      hooks: { afterCreate: null, beforeRun: null, afterRun: null, beforeRemove: null, timeoutMs: 1000 },
+    },
+    agent: {
+      maxConcurrentAgents: 1,
+      maxConcurrentAgentsByState: {},
+      maxTurns: 2,
+      maxRetryBackoffMs: 10000,
+      maxContinuationAttempts: 1,
+      successState: null,
+      stallTimeoutMs: 0,
+    },
+    codex: {
+      command: "codex app-server",
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+      approvalPolicy: "never",
+      threadSandbox: "danger-full-access",
+      turnSandboxPolicy: { type: "dangerFullAccess" },
+      readTimeoutMs: 1000,
+      turnTimeoutMs: 1000,
+      drainTimeoutMs: 0,
+      startupTimeoutMs: 0,
+      stallTimeoutMs: 0,
+      auth: { mode: "api_key", sourceHome: "/tmp/auth" },
+      provider: null,
+      sandbox: {
+        image: "symphony-codex:latest",
+        network: "",
+        security: { noNewPrivileges: true, dropCapabilities: true, gvisor: false, seccompProfile: "" },
+        resources: { memory: "4g", memoryReservation: "1g", memorySwap: "4g", cpus: "2.0", tmpfsSize: "512m" },
+        extraMounts: [],
+        envPassthrough: [],
+        logs: { driver: "json-file", maxSize: "50m", maxFile: 3 },
+        egressAllowlist: [],
+      },
+    },
+    server: { port: 4000 },
+    github: { token: "github-token", apiBaseUrl: "https://api.github.com" },
+    repos: [],
+  } as unknown as ServiceConfig;
+}
+
+function createMockDeps(): DispatcherFactoryDeps {
+  const logger = createMockLogger();
+  return {
+    tracker: {
+      fetchCandidateIssues: vi.fn(),
+      fetchIssueStatesByIds: vi.fn(),
+      fetchIssuesByStates: vi.fn(),
+      resolveStateId: vi.fn(),
+      updateIssueState: vi.fn(),
+      createComment: vi.fn(),
+      transitionIssue: vi.fn(),
+    },
+    linearClient: {} as DispatcherFactoryDeps["linearClient"],
+    workspaceManager: {} as DispatcherFactoryDeps["workspaceManager"],
+    archiveDir: "/tmp/archives",
+    pathRegistry: {} as DispatcherFactoryDeps["pathRegistry"],
+    githubToolClient: {} as DispatcherFactoryDeps["githubToolClient"],
+    logger,
+  };
+}
+
+describe("createDispatcher", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("creates AgentRunner when DISPATCH_MODE is not set (default)", () => {
+    delete process.env.DISPATCH_MODE;
+    const dispatcher = createDispatcher(() => createConfig(), createMockDeps());
+
+    expect(dispatcher).toBeInstanceOf(AgentRunner);
+  });
+
+  it("creates AgentRunner when DISPATCH_MODE is 'local'", () => {
+    process.env.DISPATCH_MODE = "local";
+    const dispatcher = createDispatcher(() => createConfig(), createMockDeps());
+
+    expect(dispatcher).toBeInstanceOf(AgentRunner);
+  });
+
+  it("creates DispatchClient when DISPATCH_MODE is 'remote'", () => {
+    process.env.DISPATCH_MODE = "remote";
+    const dispatcher = createDispatcher(() => createConfig(), createMockDeps());
+
+    expect(dispatcher).toBeInstanceOf(DispatchClient);
+  });
+
+  it("passes DISPATCH_URL to DispatchClient", () => {
+    process.env.DISPATCH_MODE = "remote";
+    process.env.DISPATCH_URL = "http://custom:9100/dispatch";
+    const dispatcher = createDispatcher(() => createConfig(), createMockDeps());
+
+    expect(dispatcher).toBeInstanceOf(DispatchClient);
+  });
+
+  it("creates logger children with correct component names", () => {
+    delete process.env.DISPATCH_MODE;
+    const deps = createMockDeps();
+    createDispatcher(() => createConfig(), deps);
+
+    expect(deps.logger.child).toHaveBeenCalledWith({ component: "agent-runner" });
+  });
+
+  it("creates dispatch-client logger child in remote mode", () => {
+    process.env.DISPATCH_MODE = "remote";
+    const deps = createMockDeps();
+    createDispatcher(() => createConfig(), deps);
+
+    expect(deps.logger.child).toHaveBeenCalledWith({ component: "dispatch-client" });
+  });
+});

--- a/tests/tracker/factory.test.ts
+++ b/tests/tracker/factory.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createTracker } from "../../src/tracker/factory.js";
+import { LinearClient } from "../../src/linear/client.js";
+import { LinearTrackerAdapter } from "../../src/tracker/linear-adapter.js";
+import { createMockLogger } from "../helpers.js";
+import type { ServiceConfig } from "../../src/core/types.js";
+
+function createConfig(): ServiceConfig {
+  return {
+    tracker: {
+      kind: "linear",
+      apiKey: "linear-token",
+      endpoint: "https://api.linear.app/graphql",
+      projectSlug: "TEST",
+      activeStates: ["In Progress"],
+      terminalStates: ["Done"],
+    },
+    polling: { intervalMs: 1000 },
+    workspace: {
+      root: "/tmp/symphony",
+      strategy: "directory",
+      branchPrefix: "symphony/",
+      hooks: { afterCreate: null, beforeRun: null, afterRun: null, beforeRemove: null, timeoutMs: 1000 },
+    },
+    agent: {
+      maxConcurrentAgents: 1,
+      maxConcurrentAgentsByState: {},
+      maxTurns: 2,
+      maxRetryBackoffMs: 10000,
+      maxContinuationAttempts: 1,
+      successState: null,
+      stallTimeoutMs: 0,
+    },
+    codex: {
+      command: "codex app-server",
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+      approvalPolicy: "never",
+      threadSandbox: "danger-full-access",
+      turnSandboxPolicy: { type: "dangerFullAccess" },
+      readTimeoutMs: 1000,
+      turnTimeoutMs: 1000,
+      drainTimeoutMs: 0,
+      startupTimeoutMs: 0,
+      stallTimeoutMs: 0,
+      auth: { mode: "api_key", sourceHome: "/tmp/auth" },
+      provider: null,
+      sandbox: {
+        image: "symphony-codex:latest",
+        network: "",
+        security: { noNewPrivileges: true, dropCapabilities: true, gvisor: false, seccompProfile: "" },
+        resources: { memory: "4g", memoryReservation: "1g", memorySwap: "4g", cpus: "2.0", tmpfsSize: "512m" },
+        extraMounts: [],
+        envPassthrough: [],
+        logs: { driver: "json-file", maxSize: "50m", maxFile: 3 },
+        egressAllowlist: [],
+      },
+    },
+    server: { port: 4000 },
+    github: { token: "github-token", apiBaseUrl: "https://api.github.com" },
+    repos: [],
+  } as unknown as ServiceConfig;
+}
+
+describe("createTracker", () => {
+  it("returns a TrackerPort and the underlying LinearClient", () => {
+    const logger = createMockLogger();
+    const result = createTracker(() => createConfig(), logger);
+
+    expect(result.tracker).toBeInstanceOf(LinearTrackerAdapter);
+    expect(result.linearClient).toBeInstanceOf(LinearClient);
+  });
+
+  it("creates logger child with linear component", () => {
+    const logger = createMockLogger();
+    createTracker(() => createConfig(), logger);
+
+    expect(logger.child).toHaveBeenCalledWith({ component: "linear" });
+  });
+
+  it("tracker delegates fetchCandidateIssues to linearClient", async () => {
+    const logger = createMockLogger();
+    const result = createTracker(() => createConfig(), logger);
+    const mockIssues = [{ id: "1", identifier: "TEST-1", title: "Test", state: "In Progress" }];
+    vi.spyOn(result.linearClient, "fetchCandidateIssues").mockResolvedValue(mockIssues as never);
+
+    const issues = await result.tracker.fetchCandidateIssues();
+
+    expect(issues).toEqual(mockIssues);
+    expect(result.linearClient.fetchCandidateIssues).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- Extract `createTracker()` factory into `src/tracker/factory.ts` -- encapsulates LinearClient + LinearTrackerAdapter construction, returns both the abstract `TrackerPort` and concrete `LinearClient` (needed by MCP GraphQL tool)
- Extract `createDispatcher()` factory into `src/dispatch/factory.ts` -- reads `DISPATCH_MODE` env var to select local `AgentRunner` or remote `DispatchClient`, hiding dispatch wiring from the service composition layer
- Simplify `src/cli/services.ts` from 106 to 96 lines by delegating to the new factories; the function now reads as a clear dependency graph without inline construction details

## Test plan

- [x] `tests/tracker/factory.test.ts` -- verifies `createTracker()` returns correct types and delegates to LinearClient
- [x] `tests/dispatch/factory.test.ts` -- verifies `DISPATCH_MODE` switching (local default, explicit local, remote), correct logger child creation
- [x] All 136 existing test files pass (1465 tests, 2 skipped)
- [x] Full CI gate: `pnpm run build && pnpm run lint && pnpm run format:check && pnpm test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
