### PR TITLE
feat(http): add OpenAPI spec generation and Swagger UI

### DIFF
--- a/src/http/openapi-paths.ts
+++ b/src/http/openapi-paths.ts
@@ -1,0 +1,374 @@
+/**
+ * OpenAPI path definitions for all Symphony API routes.
+ *
+ * Each builder function returns a group of path items keyed by route path.
+ * Used by `openapi.ts` to assemble the full spec.
+ */
+
+import { z } from "zod";
+
+import { modelUpdateSchema, transitionSchema } from "./request-schemas.js";
+import {
+  abortResponseSchema,
+  attemptsListResponseSchema,
+  errorResponseSchema,
+  refreshResponseSchema,
+  runtimeResponseSchema,
+  transitionResponseSchema,
+  validationErrorSchema,
+} from "./response-schemas.js";
+
+type JsonSchema = Record<string, unknown>;
+
+interface PathItem {
+  [method: string]: unknown;
+}
+
+function jsonContent(schema: JsonSchema): Record<string, unknown> {
+  return { "application/json": { schema } };
+}
+
+function jsonResponse(description: string, schema: JsonSchema): Record<string, unknown> {
+  return { description, content: jsonContent(schema) };
+}
+
+function errorResponse(description: string): Record<string, unknown> {
+  return jsonResponse(description, toSchema(errorResponseSchema));
+}
+
+function toSchema(zodSchema: z.ZodType): JsonSchema {
+  return z.toJSONSchema(zodSchema) as JsonSchema;
+}
+
+function pathParam(name: string, description?: string): Record<string, unknown> {
+  const param: Record<string, unknown> = {
+    name,
+    in: "path",
+    required: true,
+    schema: { type: "string" },
+  };
+  if (description) param.description = description;
+  return param;
+}
+
+export function buildStateAndMetricsPaths(): Record<string, PathItem> {
+  return {
+    "/api/v1/state": {
+      get: {
+        tags: ["State & Metrics"],
+        summary: "Get runtime state snapshot",
+        operationId: "getState",
+        responses: {
+          "200": jsonResponse("Current runtime snapshot", { type: "object" }),
+        },
+      },
+    },
+    "/api/v1/runtime": {
+      get: {
+        tags: ["State & Metrics"],
+        summary: "Get runtime metadata",
+        operationId: "getRuntime",
+        responses: {
+          "200": jsonResponse("Runtime information", toSchema(runtimeResponseSchema)),
+        },
+      },
+    },
+    "/api/v1/refresh": {
+      post: {
+        tags: ["State & Metrics"],
+        summary: "Request a tracker refresh",
+        operationId: "postRefresh",
+        responses: {
+          "202": jsonResponse("Refresh queued", toSchema(refreshResponseSchema)),
+        },
+      },
+    },
+    "/api/v1/transitions": {
+      get: {
+        tags: ["State & Metrics"],
+        summary: "Get available state transitions",
+        operationId: "getTransitions",
+        responses: {
+          "200": jsonResponse("Transitions list", { type: "object" }),
+        },
+      },
+    },
+    "/metrics": {
+      get: {
+        tags: ["State & Metrics"],
+        summary: "Prometheus-style metrics",
+        operationId: "getMetrics",
+        responses: {
+          "200": {
+            description: "Plain-text metrics",
+            content: { "text/plain": { schema: { type: "string" } } },
+          },
+        },
+      },
+    },
+  };
+}
+
+export function buildIssuePaths(): Record<string, PathItem> {
+  return {
+    "/api/v1/{issue_identifier}": {
+      get: {
+        tags: ["Issues"],
+        summary: "Get issue detail",
+        operationId: "getIssueDetail",
+        parameters: [pathParam("issue_identifier", "Issue identifier (e.g. ENG-123)")],
+        responses: {
+          "200": jsonResponse("Issue detail", { type: "object" }),
+          "404": errorResponse("Issue not found"),
+        },
+      },
+    },
+    "/api/v1/{issue_identifier}/abort": {
+      post: {
+        tags: ["Issues"],
+        summary: "Abort a running issue",
+        operationId: "abortIssue",
+        parameters: [pathParam("issue_identifier", "Issue identifier (e.g. ENG-123)")],
+        responses: {
+          "202": jsonResponse("Abort accepted", toSchema(abortResponseSchema)),
+          "200": jsonResponse("Already stopping", toSchema(abortResponseSchema)),
+          "404": errorResponse("Issue not found"),
+          "409": errorResponse("Conflict"),
+        },
+      },
+    },
+    "/api/v1/{issue_identifier}/model": {
+      post: {
+        tags: ["Issues"],
+        summary: "Update model override for an issue",
+        operationId: "updateModel",
+        parameters: [pathParam("issue_identifier", "Issue identifier (e.g. ENG-123)")],
+        requestBody: {
+          required: true,
+          content: jsonContent(toSchema(modelUpdateSchema)),
+        },
+        responses: {
+          "200": jsonResponse("Model updated", { type: "object" }),
+          "400": jsonResponse("Validation error", toSchema(validationErrorSchema)),
+        },
+      },
+    },
+    "/api/v1/{issue_identifier}/transition": {
+      post: {
+        tags: ["Issues"],
+        summary: "Transition an issue to a new state",
+        operationId: "transitionIssue",
+        parameters: [pathParam("issue_identifier", "Issue identifier (e.g. ENG-123)")],
+        requestBody: {
+          required: true,
+          content: jsonContent(toSchema(transitionSchema)),
+        },
+        responses: {
+          "200": jsonResponse("Transition applied", toSchema(transitionResponseSchema)),
+          "400": jsonResponse("Validation error", toSchema(validationErrorSchema)),
+        },
+      },
+    },
+    "/api/v1/{issue_identifier}/attempts": {
+      get: {
+        tags: ["Attempts"],
+        summary: "List attempts for an issue",
+        operationId: "listAttempts",
+        parameters: [pathParam("issue_identifier", "Issue identifier (e.g. ENG-123)")],
+        responses: {
+          "200": jsonResponse("Attempts list", toSchema(attemptsListResponseSchema)),
+          "404": errorResponse("Issue not found"),
+        },
+      },
+    },
+    "/api/v1/attempts/{attempt_id}": {
+      get: {
+        tags: ["Attempts"],
+        summary: "Get attempt detail",
+        operationId: "getAttemptDetail",
+        parameters: [pathParam("attempt_id")],
+        responses: {
+          "200": jsonResponse("Attempt detail", { type: "object" }),
+          "404": errorResponse("Attempt not found"),
+        },
+      },
+    },
+  };
+}
+
+export function buildInfrastructurePaths(): Record<string, PathItem> {
+  return {
+    ...buildWorkspacePaths(),
+    ...buildGitPaths(),
+    ...buildConfigPaths(),
+    ...buildSecretsPaths(),
+  };
+}
+
+function buildWorkspacePaths(): Record<string, PathItem> {
+  return {
+    "/api/v1/workspaces": {
+      get: {
+        tags: ["Workspaces"],
+        summary: "List workspaces",
+        operationId: "listWorkspaces",
+        responses: {
+          "200": jsonResponse("Workspace inventory", { type: "object" }),
+        },
+      },
+    },
+    "/api/v1/workspaces/{workspace_key}": {
+      delete: {
+        tags: ["Workspaces"],
+        summary: "Remove a workspace",
+        operationId: "removeWorkspace",
+        parameters: [pathParam("workspace_key")],
+        responses: {
+          "204": { description: "Workspace removed" },
+          "404": errorResponse("Workspace not found"),
+        },
+      },
+    },
+  };
+}
+
+function buildGitPaths(): Record<string, PathItem> {
+  return {
+    "/api/v1/git/context": {
+      get: {
+        tags: ["Git"],
+        summary: "Get git context for the workspace",
+        operationId: "getGitContext",
+        responses: {
+          "200": jsonResponse("Git context", { type: "object" }),
+        },
+      },
+    },
+  };
+}
+
+function buildConfigPaths(): Record<string, PathItem> {
+  return {
+    "/api/v1/config": {
+      get: {
+        tags: ["Config"],
+        summary: "Get effective configuration",
+        operationId: "getConfig",
+        responses: {
+          "200": jsonResponse("Effective config", { type: "object" }),
+        },
+      },
+    },
+    "/api/v1/config/schema": {
+      get: {
+        tags: ["Config"],
+        summary: "Get config schema",
+        operationId: "getConfigSchema",
+        responses: {
+          "200": jsonResponse("Config schema", { type: "object" }),
+        },
+      },
+    },
+    "/api/v1/config/overlay": {
+      get: {
+        tags: ["Config"],
+        summary: "Get config overlay",
+        operationId: "getConfigOverlay",
+        responses: {
+          "200": jsonResponse("Config overlay", { type: "object" }),
+        },
+      },
+      put: {
+        tags: ["Config"],
+        summary: "Update config overlay",
+        operationId: "putConfigOverlay",
+        requestBody: {
+          required: true,
+          content: jsonContent({ type: "object" }),
+        },
+        responses: {
+          "200": jsonResponse("Overlay updated", { type: "object" }),
+          "400": errorResponse("Invalid overlay payload"),
+        },
+      },
+    },
+    "/api/v1/config/overlay/{path}": {
+      patch: {
+        tags: ["Config"],
+        summary: "Set a single config overlay value",
+        operationId: "patchConfigOverlayPath",
+        parameters: [pathParam("path")],
+        requestBody: {
+          required: true,
+          content: jsonContent({
+            type: "object",
+            properties: { value: {} },
+            required: ["value"],
+          }),
+        },
+        responses: {
+          "200": jsonResponse("Value set", { type: "object" }),
+          "400": errorResponse("Invalid overlay path or payload"),
+        },
+      },
+      delete: {
+        tags: ["Config"],
+        summary: "Delete a config overlay path",
+        operationId: "deleteConfigOverlayPath",
+        parameters: [pathParam("path")],
+        responses: {
+          "204": { description: "Path deleted" },
+          "404": errorResponse("Path not found"),
+        },
+      },
+    },
+  };
+}
+
+function buildSecretsPaths(): Record<string, PathItem> {
+  return {
+    "/api/v1/secrets": {
+      get: {
+        tags: ["Secrets"],
+        summary: "List secret keys",
+        operationId: "listSecrets",
+        responses: {
+          "200": jsonResponse("Secret keys", {
+            type: "object",
+            properties: { keys: { type: "array", items: { type: "string" } } },
+          }),
+        },
+      },
+    },
+    "/api/v1/secrets/{key}": {
+      post: {
+        tags: ["Secrets"],
+        summary: "Set a secret",
+        operationId: "setSecret",
+        parameters: [pathParam("key")],
+        requestBody: {
+          required: true,
+          content: jsonContent({
+            type: "object",
+            properties: { value: { type: "string" } },
+            required: ["value"],
+          }),
+        },
+        responses: {
+          "204": { description: "Secret stored" },
+          "400": errorResponse("Invalid secret key or value"),
+        },
+      },
+      delete: {
+        tags: ["Secrets"],
+        summary: "Delete a secret",
+        operationId: "deleteSecret",
+        parameters: [pathParam("key")],
+        responses: {
+          "204": { description: "Secret deleted" },
+          "404": errorResponse("Secret not found"),
+        },
+      },
+    },
+  };
+}

--- a/src/http/openapi.ts
+++ b/src/http/openapi.ts
@@ -1,0 +1,33 @@
+/**
+ * OpenAPI 3.1 spec generator for Symphony Orchestrator.
+ *
+ * Assembles the spec from path definitions in `./openapi-paths.js`.
+ * Uses Zod 4's built-in `z.toJSONSchema()` — no external OpenAPI library needed.
+ */
+
+import { buildInfrastructurePaths, buildIssuePaths, buildStateAndMetricsPaths } from "./openapi-paths.js";
+
+/** Lazily cached spec — built once on first access, then reused. */
+let cachedSpec: Record<string, unknown> | undefined;
+
+/** Returns the OpenAPI 3.1 spec as a plain JSON-serializable object. */
+export function getOpenApiSpec(): Record<string, unknown> {
+  if (!cachedSpec) {
+    cachedSpec = {
+      openapi: "3.1.0",
+      info: {
+        title: "Symphony Orchestrator API",
+        version: "0.4.0",
+        description:
+          "REST API for the Symphony Orchestrator — manages issues, workspaces, config, and agent lifecycle.",
+      },
+      servers: [{ url: "http://localhost:4000", description: "Local Symphony instance" }],
+      paths: {
+        ...buildStateAndMetricsPaths(),
+        ...buildIssuePaths(),
+        ...buildInfrastructurePaths(),
+      },
+    };
+  }
+  return cachedSpec;
+}

--- a/src/http/response-schemas.ts
+++ b/src/http/response-schemas.ts
@@ -1,0 +1,67 @@
+/**
+ * Zod response schemas for API endpoints.
+ *
+ * These schemas define the shape of JSON response bodies.
+ * Used for OpenAPI spec generation alongside the request schemas
+ * in `./request-schemas.ts`.
+ */
+
+import { z } from "zod";
+
+/** POST /api/v1/refresh — 202 response. */
+export const refreshResponseSchema = z.object({
+  queued: z.boolean(),
+  coalesced: z.boolean(),
+  requested_at: z.string(),
+});
+
+/** POST /api/v1/:issue_identifier/abort — success response. */
+export const abortResponseSchema = z.object({
+  ok: z.literal(true),
+  status: z.literal("stopping"),
+  already_stopping: z.boolean(),
+  requested_at: z.string(),
+});
+
+/** POST /api/v1/:issue_identifier/transition — success response. */
+export const transitionResponseSchema = z.object({
+  ok: z.boolean(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  reason: z.string().optional(),
+});
+
+/** Standard error envelope used across 4xx/5xx responses. */
+export const errorResponseSchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+  }),
+});
+
+/** 400 validation error shape returned by `validateBody()` and friends. */
+export const validationErrorSchema = z.object({
+  error: z.literal("validation_error"),
+  details: z.array(
+    z.object({
+      code: z.string(),
+      path: z.array(z.union([z.string(), z.number()])),
+      message: z.string(),
+    }),
+  ),
+});
+
+/** GET /api/v1/runtime — runtime info response. */
+export const runtimeResponseSchema = z.object({
+  version: z.string(),
+  workflow_path: z.string(),
+  data_dir: z.string(),
+  feature_flags: z.record(z.string(), z.unknown()),
+  provider_summary: z.string(),
+});
+
+/** GET /api/v1/:issue_identifier/attempts — attempts list response. */
+export const attemptsListResponseSchema = z.object({
+  attempts: z.array(z.record(z.string(), z.unknown())),
+  current_attempt_id: z.string().nullable(),
+});

--- a/src/http/routes.ts
+++ b/src/http/routes.ts
@@ -15,12 +15,14 @@ import type { SecretsStore } from "../secrets/store.js";
 import { handleAttemptDetail } from "./attempt-handler.js";
 import { handleGitContext } from "./git-context.js";
 import { handleModelUpdate } from "./model-handler.js";
+import { getOpenApiSpec } from "./openapi.js";
 import { modelUpdateSchema, transitionSchema } from "./request-schemas.js";
+import { methodNotAllowed, refreshReason, sanitizeConfigValue, serializeSnapshot } from "./route-helpers.js";
+import { getSwaggerHtml } from "./swagger-html.js";
 import { handleTransition } from "./transition-handler.js";
 import { handleGetTransitions } from "./transitions-api.js";
 import { validateBody } from "./validation.js";
 import { handleWorkspaceInventory, handleWorkspaceRemove } from "./workspace-inventory.js";
-import { methodNotAllowed, refreshReason, sanitizeConfigValue, serializeSnapshot } from "./route-helpers.js";
 import type { TrackerPort } from "../tracker/port.js";
 
 import rateLimit from "express-rate-limit";
@@ -46,6 +48,7 @@ export function registerHttpRoutes(app: Express, deps: HttpRouteDeps): void {
   app.use("/api/", apiLimiter);
   app.use("/metrics", apiLimiter);
   registerStateAndMetricsRoutes(app, deps);
+  registerDocsRoutes(app);
   registerExtensionApis(app, deps);
   registerGitRoutes(app, deps);
   registerWorkspaceRoutes(app, deps);
@@ -109,6 +112,26 @@ function registerStateAndMetricsRoutes(app: Express, deps: HttpRouteDeps): void 
     .route("/api/v1/transitions")
     .get((req, res) => {
       handleGetTransitions({ orchestrator: deps.orchestrator, configStore: deps.configStore }, req, res);
+    })
+    .all((_req, res) => {
+      methodNotAllowed(res);
+    });
+}
+
+function registerDocsRoutes(app: Express): void {
+  app
+    .route("/api/v1/openapi.json")
+    .get((_req, res) => {
+      res.json(getOpenApiSpec());
+    })
+    .all((_req, res) => {
+      methodNotAllowed(res);
+    });
+
+  app
+    .route("/api/docs")
+    .get((_req, res) => {
+      res.type("html").send(getSwaggerHtml());
     })
     .all((_req, res) => {
       methodNotAllowed(res);

--- a/src/http/swagger-html.ts
+++ b/src/http/swagger-html.ts
@@ -1,0 +1,28 @@
+/**
+ * Returns an HTML page that renders Swagger UI from CDN.
+ *
+ * The page fetches `/api/v1/openapi.json` from the same host
+ * and renders it using swagger-ui-dist from unpkg.
+ */
+
+const SWAGGER_CDN = "https://unpkg.com/swagger-ui-dist@5";
+
+/** Returns a self-contained HTML string for the Swagger UI docs page. */
+export function getSwaggerHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Symphony API Docs</title>
+  <link rel="stylesheet" href="${SWAGGER_CDN}/swagger-ui.css" />
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="${SWAGGER_CDN}/swagger-ui-bundle.js"></script>
+  <script>
+    SwaggerUIBundle({ url: "/api/v1/openapi.json", dom_id: "#swagger-ui" });
+  </script>
+</body>
+</html>`;
+}

--- a/tests/http/openapi.test.ts
+++ b/tests/http/openapi.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { getOpenApiSpec } from "../../src/http/openapi.js";
+import { getSwaggerHtml } from "../../src/http/swagger-html.js";
+
+describe("getOpenApiSpec", () => {
+  const spec = getOpenApiSpec();
+
+  it("returns a valid OpenAPI 3.1 document", () => {
+    expect(spec.openapi).toBe("3.1.0");
+    expect(spec.info).toBeDefined();
+    expect(spec.paths).toBeDefined();
+  });
+
+  it("includes server info", () => {
+    const servers = spec.servers as Array<{ url: string; description: string }>;
+    expect(servers).toHaveLength(1);
+    expect(servers[0].url).toBe("http://localhost:4000");
+  });
+
+  it("includes core state routes", () => {
+    const paths = spec.paths as Record<string, unknown>;
+    expect(paths["/api/v1/state"]).toBeDefined();
+    expect(paths["/api/v1/runtime"]).toBeDefined();
+    expect(paths["/api/v1/refresh"]).toBeDefined();
+    expect(paths["/metrics"]).toBeDefined();
+  });
+
+  it("includes issue routes with path parameters", () => {
+    const paths = spec.paths as Record<string, Record<string, Record<string, unknown>>>;
+    expect(paths["/api/v1/{issue_identifier}"]).toBeDefined();
+    expect(paths["/api/v1/{issue_identifier}/abort"]).toBeDefined();
+    expect(paths["/api/v1/{issue_identifier}/model"]).toBeDefined();
+    expect(paths["/api/v1/{issue_identifier}/transition"]).toBeDefined();
+    expect(paths["/api/v1/{issue_identifier}/attempts"]).toBeDefined();
+    expect(paths["/api/v1/attempts/{attempt_id}"]).toBeDefined();
+  });
+
+  it("includes workspace, git, config, and secrets routes", () => {
+    const paths = spec.paths as Record<string, unknown>;
+    expect(paths["/api/v1/workspaces"]).toBeDefined();
+    expect(paths["/api/v1/workspaces/{workspace_key}"]).toBeDefined();
+    expect(paths["/api/v1/git/context"]).toBeDefined();
+    expect(paths["/api/v1/config"]).toBeDefined();
+    expect(paths["/api/v1/config/overlay"]).toBeDefined();
+    expect(paths["/api/v1/secrets"]).toBeDefined();
+    expect(paths["/api/v1/secrets/{key}"]).toBeDefined();
+  });
+
+  it("references request body schemas on POST endpoints", () => {
+    const paths = spec.paths as Record<string, Record<string, Record<string, unknown>>>;
+    const modelPost = paths["/api/v1/{issue_identifier}/model"].post;
+    expect(modelPost.requestBody).toBeDefined();
+
+    const transitionPost = paths["/api/v1/{issue_identifier}/transition"].post;
+    expect(transitionPost.requestBody).toBeDefined();
+  });
+
+  it("groups routes by tags", () => {
+    const paths = spec.paths as Record<string, Record<string, Record<string, string[]>>>;
+    expect(paths["/api/v1/state"].get.tags).toContain("State & Metrics");
+    expect(paths["/api/v1/{issue_identifier}/abort"].post.tags).toContain("Issues");
+    expect(paths["/api/v1/{issue_identifier}/attempts"].get.tags).toContain("Attempts");
+    expect(paths["/api/v1/workspaces"].get.tags).toContain("Workspaces");
+    expect(paths["/api/v1/git/context"].get.tags).toContain("Git");
+    expect(paths["/api/v1/config"].get.tags).toContain("Config");
+    expect(paths["/api/v1/secrets"].get.tags).toContain("Secrets");
+  });
+
+  it("produces JSON-serializable output", () => {
+    const serialized = JSON.stringify(spec);
+    expect(() => JSON.parse(serialized)).not.toThrow();
+  });
+});
+
+describe("getSwaggerHtml", () => {
+  const html = getSwaggerHtml();
+
+  it("returns an HTML document", () => {
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("</html>");
+  });
+
+  it("loads Swagger UI from CDN", () => {
+    expect(html).toContain("swagger-ui-bundle.js");
+    expect(html).toContain("swagger-ui.css");
+    expect(html).toContain("unpkg.com/swagger-ui-dist");
+  });
+
+  it("points to the openapi.json endpoint", () => {
+    expect(html).toContain("/api/v1/openapi.json");
+  });
+});


### PR DESCRIPTION
## Summary

- Auto-generates an OpenAPI 3.1 spec from existing Zod request/response schemas using Zod 4's built-in `z.toJSONSchema()` — no external dependency needed
- Serves the spec at `GET /api/v1/openapi.json` (lazily cached) and a Swagger UI explorer at `GET /api/docs` (CDN-loaded, zero npm overhead)
- Covers all 25+ API routes grouped by tag: State & Metrics, Issues, Attempts, Workspaces, Git, Config, Secrets

## New files

| File | Lines | Purpose |
|------|-------|---------|
| `src/http/response-schemas.ts` | 67 | Zod schemas for response bodies (refresh, abort, transition, runtime, validation error) |
| `src/http/openapi.ts` | 33 | Thin coordinator — assembles and caches the OpenAPI spec |
| `src/http/openapi-paths.ts` | 374 | Declarative path definitions for all API routes |
| `src/http/swagger-html.ts` | 28 | Returns self-contained HTML loading Swagger UI from unpkg CDN |
| `tests/http/openapi.test.ts` | 93 | Tests for spec structure, tags, request body refs, serialization, and Swagger HTML |

## Design decisions

- **No new dependency**: Zod 4 ships `z.toJSONSchema()` natively, so `@asteasolutions/zod-to-openapi` (Zod 3 only) is unnecessary
- **Lazy caching**: The spec object (including schema conversions) is built once on first request, then reused
- **Generic `pathParam()` helper**: Replaces 7 inline parameter definitions with a single reusable function

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm run lint` — 0 errors, 0 new warnings
- [x] `pnpm run format:check` passes
- [x] `pnpm test` — 135 test files, 1467 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
