### PR TITLE
feat(persistence): SQLite-backed AttemptStore with JSONL migration

### DIFF
--- a/src/cli/services.ts
+++ b/src/cli/services.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import { AttemptStore } from "../core/attempt-store.js";
 import { TypedEventBus } from "../core/event-bus.js";
 import type { SymphonyEventMap } from "../core/symphony-events.js";
@@ -7,8 +9,11 @@ import type { ConfigStore } from "../config/store.js";
 import { createDispatcher } from "../dispatch/factory.js";
 import { HttpServer } from "../http/server.js";
 import type { createLogger } from "../core/logger.js";
+import type { AttemptStorePort } from "../core/attempt-store-port.js";
+import type { SymphonyLogger } from "../core/types.js";
 import { NotificationManager } from "../notification/manager.js";
 import { Orchestrator } from "../orchestrator/orchestrator.js";
+import { SqliteAttemptStore } from "../persistence/sqlite/attempt-store-sqlite.js";
 import { PathRegistry } from "../workspace/path-registry.js";
 import type { SecretsStore } from "../secrets/store.js";
 import { createTracker } from "../tracker/factory.js";
@@ -26,8 +31,9 @@ export async function createServices(
     process.env.GITHUB_TOKEN = persistedGithubToken;
   }
 
-  const attemptStore = new AttemptStore(archiveDir, logger.child({ component: "attempt-store" }));
-  await attemptStore.start();
+  const persistenceMode = process.env.SYMPHONY_PERSISTENCE ?? "sqlite";
+  const storeLogger = logger.child({ component: "attempt-store" });
+  const attemptStore = await createAttemptStore(persistenceMode, archiveDir, storeLogger);
 
   const { tracker, linearClient } = createTracker(() => configStore.getConfig(), logger);
 
@@ -92,4 +98,16 @@ export async function createServices(
   });
 
   return { orchestrator, httpServer, notificationManager, linearClient };
+}
+
+async function createAttemptStore(mode: string, archiveDir: string, logger: SymphonyLogger): Promise<AttemptStorePort> {
+  if (mode === "jsonl") {
+    const store = new AttemptStore(archiveDir, logger);
+    await store.start();
+    return store;
+  }
+  const store = new SqliteAttemptStore(path.join(archiveDir, "symphony.db"), logger);
+  await store.start();
+  await store.migrateFromArchive(archiveDir);
+  return store;
 }

--- a/src/core/attempt-store-port.ts
+++ b/src/core/attempt-store-port.ts
@@ -1,0 +1,25 @@
+/**
+ * Port interface for attempt storage.
+ *
+ * Both the JSONL-based `AttemptStore` and the SQLite-backed
+ * `SqliteAttemptStore` implement this contract. Consumers should
+ * depend on this interface rather than a concrete implementation.
+ */
+
+import type { AttemptEvent, AttemptRecord } from "./types.js";
+
+export interface AttemptStorePort {
+  start(): Promise<void>;
+  getAttempt(attemptId: string): AttemptRecord | null;
+  getAllAttempts(): AttemptRecord[];
+  getEvents(attemptId: string): AttemptEvent[];
+  getAttemptsForIssue(issueIdentifier: string): AttemptRecord[];
+  createAttempt(attempt: AttemptRecord): Promise<void>;
+  updateAttempt(attemptId: string, patch: Partial<AttemptRecord>): Promise<void>;
+  appendEvent(event: AttemptEvent): Promise<void>;
+}
+
+/** Sort attempts newest-first by `startedAt`. Shared by both store implementations. */
+export function sortAttemptsDesc(left: AttemptRecord, right: AttemptRecord): number {
+  return right.startedAt.localeCompare(left.startedAt);
+}

--- a/src/core/attempt-store.ts
+++ b/src/core/attempt-store.ts
@@ -1,11 +1,8 @@
 import { appendFile, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import { sortAttemptsDesc } from "./attempt-store-port.js";
 import type { AttemptEvent, AttemptRecord, SymphonyLogger } from "./types.js";
-
-function sortAttemptsDesc(left: AttemptRecord, right: AttemptRecord): number {
-  return right.startedAt.localeCompare(left.startedAt);
-}
 
 export class AttemptStore {
   private readonly attempts = new Map<string, AttemptRecord>();

--- a/src/orchestrator/retry-failure.ts
+++ b/src/orchestrator/retry-failure.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { AttemptStore } from "../core/attempt-store.js";
+import type { AttemptStorePort } from "../core/attempt-store-port.js";
 import { issueView, nowIso } from "./views.js";
 import type { Issue, ModelSelection, RecentEvent, AttemptRecord } from "../core/types.js";
 import type { RunningEntry } from "./runtime-types.js";
@@ -72,7 +72,7 @@ function buildFailureAttemptData(
 }
 
 interface PersistRetryFailureInput {
-  attemptStore: Pick<AttemptStore, "updateAttempt" | "createAttempt">;
+  attemptStore: Pick<AttemptStorePort, "updateAttempt" | "createAttempt">;
   runningEntry: RunningEntry | null;
   issue: Issue;
   selection: ModelSelection;
@@ -125,7 +125,7 @@ export async function handleRetryLaunchFailure(
     runningEntries: Map<string, RunningEntry>;
     clearRetryEntry: (issueId: string) => void;
     deps: {
-      attemptStore: Pick<AttemptStore, "updateAttempt" | "createAttempt">;
+      attemptStore: Pick<AttemptStorePort, "updateAttempt" | "createAttempt">;
       logger: {
         error: (meta: Record<string, unknown>, message: string) => void;
         warn: (meta: Record<string, unknown>, message: string) => void;

--- a/src/orchestrator/runtime-types.ts
+++ b/src/orchestrator/runtime-types.ts
@@ -1,5 +1,5 @@
 import type { RunAttemptDispatcher } from "../dispatch/types.js";
-import { AttemptStore } from "../core/attempt-store.js";
+import type { AttemptStorePort } from "../core/attempt-store-port.js";
 import { ConfigStore } from "../config/store.js";
 import type { TypedEventBus } from "../core/event-bus.js";
 import type { SymphonyEventMap } from "../core/symphony-events.js";
@@ -40,7 +40,7 @@ export interface RunningEntry {
 export type RetryRuntimeEntry = RetryEntry & { issue: Issue; workspaceKey: string | null };
 
 export interface OrchestratorDeps {
-  attemptStore: AttemptStore;
+  attemptStore: AttemptStorePort;
   configStore: ConfigStore;
   tracker: TrackerPort;
   workspaceManager: WorkspaceManager;

--- a/src/persistence/sqlite/attempt-store-sqlite.ts
+++ b/src/persistence/sqlite/attempt-store-sqlite.ts
@@ -1,0 +1,110 @@
+/**
+ * SQLite-backed implementation of the AttemptStore interface.
+ *
+ * Provides the same public API as the JSONL-based `AttemptStore` but
+ * persists data in a SQLite database for queryable, durable storage.
+ */
+
+import { desc, eq } from "drizzle-orm";
+import type { AttemptEvent, AttemptRecord, SymphonyLogger } from "../../core/types.js";
+import { closeDatabase, openDatabase, type SymphonyDatabase } from "./database.js";
+import { attemptEvents, attempts } from "./schema.js";
+import { rowToAttemptRecord, attemptRecordToRow, rowToAttemptEvent, attemptEventToRow } from "./mappers.js";
+import { migrateFromJsonl } from "./migrator.js";
+
+export class SqliteAttemptStore {
+  private db: SymphonyDatabase | null = null;
+
+  constructor(
+    private readonly dbPath: string,
+    private readonly logger: SymphonyLogger,
+  ) {}
+
+  async start(): Promise<void> {
+    this.db = openDatabase(this.dbPath);
+    this.logger.info({ dbPath: this.dbPath }, "SQLite attempt store opened");
+  }
+
+  getAttempt(attemptId: string): AttemptRecord | null {
+    const rows = this.getDb().select().from(attempts).where(eq(attempts.attemptId, attemptId)).all();
+    if (rows.length === 0) return null;
+    return rowToAttemptRecord(rows[0]);
+  }
+
+  getAllAttempts(): AttemptRecord[] {
+    const rows = this.getDb().select().from(attempts).all();
+    return rows.map(rowToAttemptRecord);
+  }
+
+  getEvents(attemptId: string): AttemptEvent[] {
+    const rows = this.getDb()
+      .select()
+      .from(attemptEvents)
+      .where(eq(attemptEvents.attemptId, attemptId))
+      .orderBy(attemptEvents.timestamp)
+      .all();
+    return rows.map(rowToAttemptEvent);
+  }
+
+  getAttemptsForIssue(issueIdentifier: string): AttemptRecord[] {
+    const rows = this.getDb()
+      .select()
+      .from(attempts)
+      .where(eq(attempts.issueIdentifier, issueIdentifier))
+      .orderBy(desc(attempts.startedAt))
+      .all();
+    return rows.map(rowToAttemptRecord);
+  }
+
+  async createAttempt(attempt: AttemptRecord): Promise<void> {
+    const row = attemptRecordToRow(attempt);
+    this.getDb().insert(attempts).values(row).onConflictDoNothing().run();
+  }
+
+  async updateAttempt(attemptId: string, patch: Partial<AttemptRecord>): Promise<void> {
+    const current = this.getAttempt(attemptId);
+    if (!current) {
+      throw new Error(`unknown attempt id: ${attemptId}`);
+    }
+    const merged = { ...current, ...patch };
+    const row = attemptRecordToRow(merged);
+    this.getDb().update(attempts).set(row).where(eq(attempts.attemptId, attemptId)).run();
+  }
+
+  async appendEvent(event: AttemptEvent): Promise<void> {
+    const row = attemptEventToRow(event);
+    this.getDb().insert(attemptEvents).values(row).run();
+  }
+
+  /**
+   * Migrate existing JSONL archive files into this SQLite database.
+   * Idempotent — safe to call on every startup.
+   */
+  async migrateFromArchive(archiveDir: string): Promise<void> {
+    const db = this.getDb();
+    const existing = db.select().from(attempts).limit(1).all();
+    if (existing.length > 0) return;
+
+    const result = await migrateFromJsonl(db, archiveDir, this.logger);
+    if (result.attemptCount > 0) {
+      this.logger.info(
+        { attempts: result.attemptCount, events: result.eventCount },
+        "migrated JSONL archives to SQLite",
+      );
+    }
+  }
+
+  close(): void {
+    if (this.db) {
+      closeDatabase(this.db);
+      this.db = null;
+    }
+  }
+
+  private getDb(): SymphonyDatabase {
+    if (!this.db) {
+      throw new Error("SqliteAttemptStore not started — call start() first");
+    }
+    return this.db;
+  }
+}

--- a/src/persistence/sqlite/index.ts
+++ b/src/persistence/sqlite/index.ts
@@ -1,3 +1,4 @@
 export { openDatabase, closeDatabase } from "./database.js";
 export type { SymphonyDatabase } from "./database.js";
 export { attempts, attemptEvents, issueIndex } from "./schema.js";
+export { SqliteAttemptStore } from "./attempt-store-sqlite.js";

--- a/src/persistence/sqlite/mappers.ts
+++ b/src/persistence/sqlite/mappers.ts
@@ -1,0 +1,129 @@
+/**
+ * Mapping functions between SQLite row shapes and TypeScript domain types.
+ *
+ * Handles the camelCase ↔ snake_case conversion and the flattening of
+ * nested objects (e.g. `tokenUsage`) into individual columns.
+ */
+
+import type { AttemptEvent, AttemptRecord, TokenUsageSnapshot } from "../../core/types.js";
+import type { attempts, attemptEvents } from "./schema.js";
+
+/** Row shape returned by Drizzle selects on the `attempts` table. */
+type AttemptRow = typeof attempts.$inferSelect;
+
+/** Row shape for Drizzle inserts on the `attempts` table. */
+type AttemptInsertRow = typeof attempts.$inferInsert;
+
+/** Row shape returned by Drizzle selects on the `attempt_events` table. */
+type AttemptEventRow = typeof attemptEvents.$inferSelect;
+
+/** Row shape for Drizzle inserts on the `attempt_events` table. */
+type AttemptEventInsertRow = typeof attemptEvents.$inferInsert;
+
+/** Convert a database row to an `AttemptRecord`. */
+export function rowToAttemptRecord(row: AttemptRow): AttemptRecord {
+  const tokenUsage = buildTokenUsage(row.inputTokens, row.outputTokens, row.totalTokens);
+  return {
+    attemptId: row.attemptId,
+    issueId: row.issueId,
+    issueIdentifier: row.issueIdentifier,
+    title: row.title,
+    workspaceKey: row.workspaceKey ?? null,
+    workspacePath: row.workspacePath ?? null,
+    status: row.status as AttemptRecord["status"],
+    attemptNumber: row.attemptNumber ?? null,
+    startedAt: row.startedAt,
+    endedAt: row.endedAt ?? null,
+    model: row.model,
+    reasoningEffort: (row.reasoningEffort as AttemptRecord["reasoningEffort"]) ?? null,
+    modelSource: row.modelSource as AttemptRecord["modelSource"],
+    threadId: row.threadId ?? null,
+    turnId: row.turnId ?? null,
+    turnCount: row.turnCount,
+    errorCode: row.errorCode ?? null,
+    errorMessage: row.errorMessage ?? null,
+    tokenUsage,
+    pullRequestUrl: row.pullRequestUrl ?? null,
+    stopSignal: (row.stopSignal as AttemptRecord["stopSignal"]) ?? null,
+  };
+}
+
+/** Convert an `AttemptRecord` to a database insert row. */
+export function attemptRecordToRow(record: AttemptRecord): AttemptInsertRow {
+  return {
+    attemptId: record.attemptId,
+    issueId: record.issueId,
+    issueIdentifier: record.issueIdentifier,
+    title: record.title,
+    workspaceKey: record.workspaceKey,
+    workspacePath: record.workspacePath,
+    status: record.status,
+    attemptNumber: record.attemptNumber,
+    startedAt: record.startedAt,
+    endedAt: record.endedAt,
+    model: record.model,
+    reasoningEffort: record.reasoningEffort,
+    modelSource: record.modelSource,
+    threadId: record.threadId,
+    turnId: record.turnId,
+    turnCount: record.turnCount,
+    errorCode: record.errorCode,
+    errorMessage: record.errorMessage,
+    inputTokens: record.tokenUsage?.inputTokens ?? null,
+    outputTokens: record.tokenUsage?.outputTokens ?? null,
+    totalTokens: record.tokenUsage?.totalTokens ?? null,
+    pullRequestUrl: record.pullRequestUrl ?? null,
+    stopSignal: record.stopSignal ?? null,
+  };
+}
+
+/** Convert a database row to an `AttemptEvent`. */
+export function rowToAttemptEvent(row: AttemptEventRow): AttemptEvent {
+  const usage = buildTokenUsage(row.inputTokens, row.outputTokens, row.totalTokens);
+  const metadata = row.metadata ? (JSON.parse(row.metadata) as Record<string, unknown>) : null;
+  return {
+    attemptId: row.attemptId,
+    at: row.timestamp,
+    issueId: row.issueId ?? null,
+    issueIdentifier: row.issueIdentifier ?? null,
+    sessionId: row.sessionId ?? null,
+    event: row.type,
+    message: row.message,
+    content: row.content ?? null,
+    usage,
+    metadata,
+  };
+}
+
+/** Convert an `AttemptEvent` to a database insert row. */
+export function attemptEventToRow(event: AttemptEvent): AttemptEventInsertRow {
+  return {
+    attemptId: event.attemptId,
+    timestamp: event.at,
+    issueId: event.issueId,
+    issueIdentifier: event.issueIdentifier,
+    sessionId: event.sessionId,
+    type: event.event,
+    message: event.message,
+    content: event.content ?? null,
+    inputTokens: event.usage?.inputTokens ?? null,
+    outputTokens: event.usage?.outputTokens ?? null,
+    totalTokens: event.usage?.totalTokens ?? null,
+    metadata: event.metadata ? JSON.stringify(event.metadata) : null,
+  };
+}
+
+function buildTokenUsage(
+  inputTokens: number | null,
+  outputTokens: number | null,
+  totalTokens: number | null,
+): TokenUsageSnapshot | null {
+  if (inputTokens === null && outputTokens === null && totalTokens === null) {
+    return null;
+  }
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+    totalTokens: totalTokens ?? 0,
+  };
+}

--- a/src/persistence/sqlite/migrator.ts
+++ b/src/persistence/sqlite/migrator.ts
@@ -1,0 +1,89 @@
+/**
+ * Migrates existing JSONL archive data into a SQLite database.
+ *
+ * Reads `<archiveDir>/attempts/*.json` and `<archiveDir>/events/*.jsonl`
+ * files, inserting them into the corresponding SQLite tables. Attempt
+ * inserts use ON CONFLICT DO NOTHING (keyed on attempt_id). The caller
+ * gates migration behind an emptiness check, making repeated calls safe.
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { AttemptEvent, AttemptRecord, SymphonyLogger } from "../../core/types.js";
+import type { SymphonyDatabase } from "./database.js";
+import { attempts, attemptEvents } from "./schema.js";
+import { attemptRecordToRow, attemptEventToRow } from "./mappers.js";
+
+export interface MigrationResult {
+  attemptCount: number;
+  eventCount: number;
+}
+
+/**
+ * Migrate JSON/JSONL archive files into the SQLite database.
+ *
+ * @returns Count of migrated attempt records and events.
+ */
+export async function migrateFromJsonl(
+  db: SymphonyDatabase,
+  archiveDir: string,
+  logger: SymphonyLogger,
+): Promise<MigrationResult> {
+  let attemptCount = 0;
+  let eventCount = 0;
+
+  const attemptsDir = path.join(archiveDir, "attempts");
+  const eventsDir = path.join(archiveDir, "events");
+
+  const attemptFiles = await safeReaddir(attemptsDir);
+  for (const file of attemptFiles) {
+    if (!file.endsWith(".json")) continue;
+
+    try {
+      const content = await readFile(path.join(attemptsDir, file), "utf8");
+      const record = JSON.parse(content) as AttemptRecord;
+      const row = attemptRecordToRow(record);
+      db.insert(attempts).values(row).onConflictDoNothing().run();
+      attemptCount += 1;
+    } catch (error) {
+      logger.warn({ file, error: String(error) }, "skipped corrupt attempt file during migration");
+    }
+  }
+
+  const eventFiles = await safeReaddir(eventsDir);
+  for (const file of eventFiles) {
+    if (!file.endsWith(".jsonl")) continue;
+
+    try {
+      const content = await readFile(path.join(eventsDir, file), "utf8");
+      const lines = content
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+      for (const line of lines) {
+        const event = JSON.parse(line) as AttemptEvent;
+        const row = attemptEventToRow(event);
+        db.insert(attemptEvents).values(row).run();
+        eventCount += 1;
+      }
+    } catch (error) {
+      logger.warn({ file, error: String(error) }, "skipped corrupt event file during migration");
+    }
+  }
+
+  if (attemptCount > 0 || eventCount > 0) {
+    logger.info({ attemptCount, eventCount }, "JSONL migration completed");
+  }
+
+  return { attemptCount, eventCount };
+}
+
+async function safeReaddir(dir: string): Promise<string[]> {
+  try {
+    return await readdir(dir);
+  } catch {
+    return [];
+  }
+}

--- a/tests/persistence/sqlite/attempt-store-sqlite.test.ts
+++ b/tests/persistence/sqlite/attempt-store-sqlite.test.ts
@@ -1,0 +1,352 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createLogger } from "../../../src/core/logger.js";
+import type { AttemptEvent, AttemptRecord } from "../../../src/core/types.js";
+import { SqliteAttemptStore } from "../../../src/persistence/sqlite/attempt-store-sqlite.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "symphony-sqlite-store-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function createAttempt(overrides: Partial<AttemptRecord> = {}): AttemptRecord {
+  return {
+    attemptId: "attempt-1",
+    issueId: "issue-1",
+    issueIdentifier: "MT-42",
+    title: "Characterize persistence",
+    workspaceKey: "MT-42",
+    workspacePath: "/tmp/symphony/MT-42",
+    status: "running",
+    attemptNumber: 1,
+    startedAt: "2026-03-16T10:00:00.000Z",
+    endedAt: null,
+    model: "gpt-5.4",
+    reasoningEffort: "high",
+    modelSource: "default",
+    threadId: null,
+    turnId: null,
+    turnCount: 0,
+    errorCode: null,
+    errorMessage: null,
+    tokenUsage: null,
+    pullRequestUrl: null,
+    stopSignal: null,
+    ...overrides,
+  };
+}
+
+function createEvent(overrides: Partial<AttemptEvent> = {}): AttemptEvent {
+  return {
+    attemptId: "attempt-1",
+    at: "2026-03-16T10:00:00.000Z",
+    issueId: "issue-1",
+    issueIdentifier: "MT-42",
+    sessionId: null,
+    event: "attempt.updated",
+    message: "updated",
+    content: null,
+    ...overrides,
+  };
+}
+
+async function createStore(dir: string): Promise<SqliteAttemptStore> {
+  const dbPath = path.join(dir, "test.db");
+  const store = new SqliteAttemptStore(dbPath, createLogger());
+  await store.start();
+  return store;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("SqliteAttemptStore", () => {
+  it("creates and retrieves an attempt", async () => {
+    const dir = await createTempDir();
+    const store = await createStore(dir);
+
+    const attempt = createAttempt();
+    await store.createAttempt(attempt);
+
+    expect(store.getAttempt(attempt.attemptId)).toEqual(attempt);
+    store.close();
+  });
+
+  it("returns null for unknown attempt id", async () => {
+    const dir = await createTempDir();
+    const store = await createStore(dir);
+
+    expect(store.getAttempt("nonexistent")).toBeNull();
+    store.close();
+  });
+
+  it("returns all attempts", async () => {
+    const dir = await createTempDir();
+    const store = await createStore(dir);
+
+    const first = createAttempt({ attemptId: "attempt-1" });
+    const second = createAttempt({ attemptId: "attempt-2", attemptNumber: 2 });
+
+    await store.createAttempt(first);
+    await store.createAttempt(second);
+
+    const all = store.getAllAttempts();
+    expect(all).toHaveLength(2);
+    expect(all.map((a) => a.attemptId).sort()).toEqual(["attempt-1", "attempt-2"]);
+    store.close();
+  });
+
+  it("handles duplicate createAttempt calls idempotently", async () => {
+    const dir = await createTempDir();
+    const store = await createStore(dir);
+
+    const attempt = createAttempt();
+    await store.createAttempt(attempt);
+    await store.createAttempt(attempt);
+
+    expect(store.getAllAttempts()).toHaveLength(1);
+    store.close();
+  });
+
+  it("updates an existing attempt", async () => {
+    const dir = await createTempDir();
+    const store = await createStore(dir);
+
+    const attempt = createAttempt();
+    await store.createAttempt(attempt);
+
+    await store.updateAttempt(attempt.attemptId, {
+      status: "completed",
+      endedAt: "2026-03-16T10:05:00.000Z",
+      turnCount: 5,
+    });
+
+    const updated = store.getAttempt(attempt.attemptId);
+    expect(updated).toMatchObject({
+      status: "completed",
+      endedAt: "2026-03-16T10:05:00.000Z",
+      turnCount: 5,
+      title: "Characterize persistence",
+    });
+    store.close();
+  });
+
+  it("throws when updating a nonexistent attempt", async () => {
+    const dir = await createTempDir();
+    const store = await createStore(dir);
+
+    await expect(store.updateAttempt("nonexistent", { status: "failed" })).rejects.toThrow("unknown attempt id");
+    store.close();
+  });
+
+  it("returns attempts for a specific issue", async () => {
+    const dir = await createTempDir();
+    const store = await createStore(dir);
+
+    const first = createAttempt({
+      attemptId: "attempt-1",
+      issueIdentifier: "MT-42",
+      startedAt: "2026-03-16T10:00:00.000Z",
+    });
+    const second = createAttempt({
+      attemptId: "attempt-2",
+      issueIdentifier: "MT-42",
+      startedAt: "2026-03-16T11:00:00.000Z",
+    });
+    const other = createAttempt({
+      attemptId: "attempt-3",
+      issueIdentifier: "MT-99",
+      startedAt: "2026-03-16T10:30:00.000Z",
+    });
+
+    await store.createAttempt(first);
+    await store.createAttempt(second);
+    await store.createAttempt(other);
+
+    const forIssue = store.getAttemptsForIssue("MT-42");
+    expect(forIssue).toHaveLength(2);
+    // Sorted descending by startedAt
+    expect(forIssue[0].attemptId).toBe("attempt-2");
+    expect(forIssue[1].attemptId).toBe("attempt-1");
+
+    expect(store.getAttemptsForIssue("MT-99")).toHaveLength(1);
+    expect(store.getAttemptsForIssue("NONE")).toEqual([]);
+    store.close();
+  });
+
+  it("appends and retrieves events in chronological order", async () => {
+    const dir = await createTempDir();
+    const store = await createStore(dir);
+
+    await store.createAttempt(createAttempt());
+
+    const firstEvent = createEvent({
+      at: "2026-03-16T10:01:00.000Z",
+      event: "attempt.started",
+      message: "started",
+    });
+    const secondEvent = createEvent({
+      at: "2026-03-16T10:02:00.000Z",
+      event: "attempt.completed",
+      message: "completed",
+    });
+
+    await store.appendEvent(firstEvent);
+    await store.appendEvent(secondEvent);
+
+    const events = store.getEvents("attempt-1");
+    expect(events).toHaveLength(2);
+    expect(events[0].event).toBe("attempt.started");
+    expect(events[1].event).toBe("attempt.completed");
+    store.close();
+  });
+
+  it("returns empty array for events of unknown attempt", async () => {
+    const dir = await createTempDir();
+    const store = await createStore(dir);
+
+    expect(store.getEvents("nonexistent")).toEqual([]);
+    store.close();
+  });
+
+  it("preserves token usage through round-trip", async () => {
+    const dir = await createTempDir();
+    const store = await createStore(dir);
+
+    const attempt = createAttempt({
+      tokenUsage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+    });
+    await store.createAttempt(attempt);
+
+    const retrieved = store.getAttempt(attempt.attemptId);
+    expect(retrieved?.tokenUsage).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+    });
+    store.close();
+  });
+
+  it("preserves event metadata through round-trip", async () => {
+    const dir = await createTempDir();
+    const store = await createStore(dir);
+
+    await store.createAttempt(createAttempt());
+
+    const event = createEvent({
+      metadata: { exitCode: 0, duration: 1234 },
+      usage: { inputTokens: 200, outputTokens: 100, totalTokens: 300 },
+    });
+    await store.appendEvent(event);
+
+    const events = store.getEvents("attempt-1");
+    expect(events[0].metadata).toEqual({ exitCode: 0, duration: 1234 });
+    expect(events[0].usage).toEqual({
+      inputTokens: 200,
+      outputTokens: 100,
+      totalTokens: 300,
+    });
+    store.close();
+  });
+
+  it("persists data across close/reopen cycles", async () => {
+    const dir = await createTempDir();
+    const dbPath = path.join(dir, "test.db");
+
+    const store1 = new SqliteAttemptStore(dbPath, createLogger());
+    await store1.start();
+    await store1.createAttempt(createAttempt());
+    await store1.appendEvent(createEvent());
+    store1.close();
+
+    const store2 = new SqliteAttemptStore(dbPath, createLogger());
+    await store2.start();
+
+    expect(store2.getAttempt("attempt-1")).toMatchObject({ attemptId: "attempt-1" });
+    expect(store2.getEvents("attempt-1")).toHaveLength(1);
+    store2.close();
+  });
+});
+
+describe("SqliteAttemptStore migration", () => {
+  it("migrates JSONL archive files into SQLite", async () => {
+    const archiveDir = await createTempDir();
+
+    const attemptsDir = path.join(archiveDir, "attempts");
+    const eventsDir = path.join(archiveDir, "events");
+    await mkdir(attemptsDir, { recursive: true });
+    await mkdir(eventsDir, { recursive: true });
+
+    const attempt = createAttempt({
+      status: "completed",
+      endedAt: "2026-03-16T10:05:00.000Z",
+    });
+    await writeFile(path.join(attemptsDir, "attempt-1.json"), JSON.stringify(attempt, null, 2), "utf8");
+
+    const events = [
+      createEvent({ at: "2026-03-16T10:01:00.000Z", event: "attempt.started", message: "started" }),
+      createEvent({ at: "2026-03-16T10:02:00.000Z", event: "attempt.completed", message: "completed" }),
+    ];
+    await writeFile(path.join(eventsDir, "attempt-1.jsonl"), events.map((e) => JSON.stringify(e)).join("\n") + "\n");
+
+    const dbPath = path.join(archiveDir, "symphony.db");
+    const store = new SqliteAttemptStore(dbPath, createLogger());
+    await store.start();
+    await store.migrateFromArchive(archiveDir);
+
+    expect(store.getAttempt("attempt-1")).toMatchObject({
+      attemptId: "attempt-1",
+      status: "completed",
+    });
+
+    const retrieved = store.getEvents("attempt-1");
+    expect(retrieved).toHaveLength(2);
+    expect(retrieved[0].event).toBe("attempt.started");
+    expect(retrieved[1].event).toBe("attempt.completed");
+    store.close();
+  });
+
+  it("skips migration when database already has data", async () => {
+    const archiveDir = await createTempDir();
+    const attemptsDir = path.join(archiveDir, "attempts");
+    await mkdir(attemptsDir, { recursive: true });
+
+    await writeFile(path.join(attemptsDir, "attempt-1.json"), JSON.stringify(createAttempt()), "utf8");
+
+    const dbPath = path.join(archiveDir, "symphony.db");
+    const store = new SqliteAttemptStore(dbPath, createLogger());
+    await store.start();
+
+    // Insert an attempt directly so the DB is non-empty
+    await store.createAttempt(createAttempt({ attemptId: "pre-existing" }));
+
+    // Migration should be skipped because the DB has data
+    await store.migrateFromArchive(archiveDir);
+
+    // Only the pre-existing attempt should be there, not the JSONL one
+    expect(store.getAllAttempts()).toHaveLength(1);
+    expect(store.getAttempt("pre-existing")).not.toBeNull();
+    expect(store.getAttempt("attempt-1")).toBeNull();
+    store.close();
+  });
+
+  it("handles missing archive directories gracefully", async () => {
+    const dir = await createTempDir();
+    const dbPath = path.join(dir, "test.db");
+    const store = new SqliteAttemptStore(dbPath, createLogger());
+    await store.start();
+
+    // Should not throw even with no archive dirs
+    await store.migrateFromArchive(path.join(dir, "nonexistent-archive"));
+    expect(store.getAllAttempts()).toEqual([]);
+    store.close();
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `SqliteAttemptStore` as a drop-in replacement for the JSONL-based `AttemptStore`, backed by better-sqlite3 via Drizzle ORM with WAL mode
- Extracts `AttemptStorePort` interface so both store implementations share a typed contract, decoupling the orchestrator from any concrete persistence backend
- Adds `SYMPHONY_PERSISTENCE` env var to select backend at startup (`"sqlite"` default, `"jsonl"` fallback) with automatic one-time migration of existing JSON/JSONL archives
- Introduces `mappers.ts` for camelCase/snake_case round-trip conversion and `migrator.ts` for idempotent archive import

## Test plan

- [x] 15 new tests covering all CRUD operations, round-trip fidelity (tokenUsage, metadata), close/reopen durability, migration from JSONL fixtures, migration skip when DB has data, and missing archive graceful handling
- [x] All 1471 existing tests pass (135 test files, 0 failures)
- [x] Build, lint, format:check, knip all pass
- [x] Pre-push hook ran full CI gate successfully
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
