### PR TITLE
fix(cli): wire eventBus.destroy() into shutdown to prevent listener leak

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,12 +4,14 @@ import { parseArgs } from "node:util";
 
 import { ConfigOverlayStore } from "../config/overlay.js";
 import { ConfigStore } from "../config/store.js";
+import { TypedEventBus } from "../core/event-bus.js";
 import { HttpServer } from "../http/server.js";
 import { createLogger } from "../core/logger.js";
 import { getErrorTracker, initErrorTracking } from "../core/error-tracking.js";
 import { loadFlags } from "../core/feature-flags.js";
 import { Orchestrator } from "../orchestrator/orchestrator.js";
 import { SecretsStore } from "../secrets/store.js";
+import type { SymphonyEventMap } from "../core/symphony-events.js";
 import type { ValidationError } from "../core/types.js";
 import { createServices } from "./services.js";
 import { wireNotifications, watchConfigChanges } from "./notifications.js";
@@ -88,14 +90,14 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   const services = await createServices(configStore, overlayStore, secretsStore, archiveDir, logger);
   wireNotifications(services.notificationManager, configStore, logger);
 
-  const { orchestrator, httpServer } = services;
+  const { orchestrator, httpServer, eventBus } = services;
   await cleanupTransientWorkspaceDirs(config.workspace.root);
   if (!needsSetup) {
     await orchestrator.start();
   }
   await httpServer.start(port);
 
-  const shutdown = buildShutdown(httpServer, orchestrator, configStore, overlayStore, logger);
+  const shutdown = buildShutdown(httpServer, orchestrator, configStore, overlayStore, eventBus, logger);
   logger.info({ workflowPath, port, logDir: archiveDir }, "service started");
   watchConfigChanges(configStore, services.notificationManager, config.server.port, logger);
 
@@ -161,6 +163,7 @@ function buildShutdown(
   orchestrator: Orchestrator,
   configStore: ConfigStore,
   overlayStore: ConfigOverlayStore,
+  eventBus: TypedEventBus<SymphonyEventMap>,
   logger: ReturnType<typeof createLogger>,
 ): () => Promise<void> {
   let shuttingDown = false;
@@ -184,6 +187,7 @@ function buildShutdown(
       .catch((error: unknown) => {
         logger.warn({ error: String(error) }, "error tracker flush failed");
       });
+    eventBus.destroy();
   };
 }
 

--- a/src/cli/services.ts
+++ b/src/cli/services.ts
@@ -98,7 +98,7 @@ export async function createServices(
     archiveDir,
   });
 
-  return { orchestrator, httpServer, notificationManager, linearClient };
+  return { orchestrator, httpServer, notificationManager, linearClient, eventBus };
 }
 
 async function createAttemptStore(mode: string, archiveDir: string, logger: SymphonyLogger): Promise<AttemptStorePort> {


### PR DESCRIPTION
## Summary

- Exposes `eventBus` from `createServices()` return object in `src/cli/services.ts`
- Destructures `eventBus` at the `main()` call site and passes it to `buildShutdown()`
- Calls `eventBus.destroy()` at the end of the shutdown sequence, after `getErrorTracker().flush()`, to clear all registered listeners

## Test plan

- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npm run lint` — no new errors (2 pre-existing warnings in unrelated files)
- [x] `npm run format:check` — all files properly formatted
- [x] `npm test` — 139 test files, 1496 tests pass
- [x] `npm run knip` — no new dead code
- [x] `semgrep` — 0 findings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
