### PR TITLE
feat(dashboard): live agent event log panel in issue-inspector (#15)

### DIFF
--- a/frontend/src/components/issue-inspector.ts
+++ b/frontend/src/components/issue-inspector.ts
@@ -15,11 +15,21 @@ import {
   buildWorkspaceSection,
 } from "./issue-inspector-sections";
 import { createIssueAbortAction } from "./issue-inspector-abort";
+import { createLiveLog } from "./live-log.js";
+import { subscribeIssueEvents } from "../state/event-source.js";
 
 interface IssueInspectorOptions {
   mode: "page" | "drawer";
   initialId?: string;
   onClose?: () => void;
+}
+
+function buildLiveLogSection(logEl: HTMLElement): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "issue-section mc-panel expand-in";
+  section.append(Object.assign(document.createElement("h2"), { textContent: "Live log" }));
+  section.appendChild(logEl);
+  return section;
 }
 
 export function createIssueInspector(options: IssueInspectorOptions): {
@@ -116,6 +126,8 @@ export function createIssueInspector(options: IssueInspectorOptions): {
 
   let poll = 0;
   let hydrated = false;
+  const liveLog = createLiveLog();
+  let unsubscribeEvents: (() => void) | null = null;
 
   function renderLoading(): void {
     content.replaceChildren(skeletonCard(), skeletonCard(), skeletonCard());
@@ -143,9 +155,13 @@ export function createIssueInspector(options: IssueInspectorOptions): {
       formatDuration(computeDurationSeconds(detail.startedAt, detail.updated_at ?? detail.updatedAt)),
     );
 
+    const isActive = detail.status === "running" || detail.status === "retrying";
+    const liveLogSection = isActive ? buildLiveLogSection(liveLog.el) : null;
+
     const sections = [
       buildDescriptionSection(detail),
       buildRetrySection(detail),
+      liveLogSection,
       buildActivitySection(detail),
       buildWorkspaceSection(detail),
       buildModelSection(detail),
@@ -189,6 +205,9 @@ export function createIssueInspector(options: IssueInspectorOptions): {
     abortAction.sync(null);
     content.replaceChildren();
     content.scrollTop = 0;
+    liveLog.clear();
+    unsubscribeEvents?.();
+    unsubscribeEvents = subscribeIssueEvents(id, (entry) => liveLog.append(entry));
     await refresh();
     window.clearInterval(poll);
     poll = window.setInterval(() => {
@@ -198,6 +217,8 @@ export function createIssueInspector(options: IssueInspectorOptions): {
 
   function destroy(): void {
     window.clearInterval(poll);
+    unsubscribeEvents?.();
+    unsubscribeEvents = null;
   }
 
   if (currentId) {

--- a/frontend/src/components/live-log.ts
+++ b/frontend/src/components/live-log.ts
@@ -1,0 +1,56 @@
+import type { AgentEventPayload } from "../state/event-source.js";
+
+export interface LiveLog {
+  el: HTMLElement;
+  append(entry: AgentEventPayload): void;
+  clear(): void;
+}
+
+export function createLiveLog(): LiveLog {
+  const el = document.createElement("div");
+  el.className = "live-log";
+
+  const empty = document.createElement("div");
+  empty.className = "live-log__empty text-secondary";
+  empty.textContent = "Waiting for agent events\u2026";
+  el.appendChild(empty);
+
+  let hasEntries = false;
+
+  function append(entry: AgentEventPayload): void {
+    if (!hasEntries) {
+      el.removeChild(empty);
+      hasEntries = true;
+    }
+    const row = document.createElement("div");
+    row.className = "live-log__row";
+
+    const ts = document.createElement("span");
+    ts.className = "live-log__ts text-mono";
+    ts.textContent = new Date().toLocaleTimeString("en-US", { hour12: false });
+
+    const chip = document.createElement("span");
+    chip.className = "live-log__type";
+    chip.textContent = entry.type;
+
+    const msg = document.createElement("span");
+    msg.className = "live-log__msg";
+    msg.textContent = entry.message;
+
+    row.append(ts, " ", chip, " ", msg);
+    el.appendChild(row);
+
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
+    if (atBottom) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }
+
+  function clear(): void {
+    el.innerHTML = "";
+    el.appendChild(empty);
+    hasEntries = false;
+  }
+
+  return { el, append, clear };
+}

--- a/frontend/src/state/event-source.ts
+++ b/frontend/src/state/event-source.ts
@@ -31,9 +31,12 @@ function openConnection(): void {
   };
 
   eventSource.onmessage = (event: MessageEvent) => {
-    const data = JSON.parse(String(event.data)) as { type: string };
+    const data = JSON.parse(String(event.data)) as { type: string; payload?: unknown };
     if (LIFECYCLE_EVENTS.has(data.type)) {
       pollOnce().catch(() => {});
+    }
+    if (data.type === "agent.event") {
+      window.dispatchEvent(new CustomEvent("symphony:agent-event", { detail: data.payload }));
     }
   };
 
@@ -58,4 +61,23 @@ function cleanup(): void {
     source.close();
     source = null;
   }
+}
+
+export interface AgentEventPayload {
+  issueId: string;
+  identifier: string;
+  type: string;
+  message: string;
+  sessionId: string | null;
+}
+
+export function subscribeIssueEvents(identifier: string, handler: (event: AgentEventPayload) => void): () => void {
+  const listener = (e: Event) => {
+    const payload = (e as CustomEvent<AgentEventPayload>).detail;
+    if (payload.identifier === identifier) {
+      handler(payload);
+    }
+  };
+  window.addEventListener("symphony:agent-event", listener);
+  return () => window.removeEventListener("symphony:agent-event", listener);
 }

--- a/tests/frontend/event-source.test.ts
+++ b/tests/frontend/event-source.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { subscribeIssueEvents, type AgentEventPayload } from "../../frontend/src/state/event-source";
+
+// Provide a minimal window stub so subscribeIssueEvents can run in Node.
+const fakeTarget = new EventTarget();
+const originalWindow = global.window;
+beforeEach(() => {
+  // @ts-expect-error -- intentional stub for tests
+  global.window = {
+    addEventListener: fakeTarget.addEventListener.bind(fakeTarget),
+    removeEventListener: fakeTarget.removeEventListener.bind(fakeTarget),
+    dispatchEvent: fakeTarget.dispatchEvent.bind(fakeTarget),
+  };
+});
+afterEach(() => {
+  global.window = originalWindow;
+});
+
+function makePayload(overrides: Partial<AgentEventPayload> = {}): AgentEventPayload {
+  return {
+    issueId: "id-1",
+    identifier: "ENG-1",
+    type: "tool_use",
+    message: "Running tests",
+    sessionId: null,
+    ...overrides,
+  };
+}
+
+function dispatch(payload: AgentEventPayload): void {
+  fakeTarget.dispatchEvent(new CustomEvent("symphony:agent-event", { detail: payload }));
+}
+
+describe("subscribeIssueEvents", () => {
+  let handler: ReturnType<typeof vi.fn>;
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    handler = vi.fn();
+  });
+
+  afterEach(() => {
+    unsubscribe?.();
+  });
+
+  it("calls the handler when the identifier matches", () => {
+    unsubscribe = subscribeIssueEvents("ENG-1", handler);
+    dispatch(makePayload({ identifier: "ENG-1" }));
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(makePayload({ identifier: "ENG-1" }));
+  });
+
+  it("ignores events for a different identifier", () => {
+    unsubscribe = subscribeIssueEvents("ENG-1", handler);
+    dispatch(makePayload({ identifier: "ENG-2" }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns an unsubscribe function that stops further calls", () => {
+    unsubscribe = subscribeIssueEvents("ENG-1", handler);
+    unsubscribe();
+    dispatch(makePayload({ identifier: "ENG-1" }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("supports multiple independent subscriptions for the same identifier", () => {
+    const handler2 = vi.fn();
+    unsubscribe = subscribeIssueEvents("ENG-1", handler);
+    const unsub2 = subscribeIssueEvents("ENG-1", handler2);
+    dispatch(makePayload({ identifier: "ENG-1" }));
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler2).toHaveBeenCalledOnce();
+    unsub2();
+  });
+});


### PR DESCRIPTION
## Summary

- Extends `event-source.ts` to dispatch a `symphony:agent-event` CustomEvent on `window` for every `agent.event` SSE message, and exports a `subscribeIssueEvents(identifier, handler)` subscription helper with automatic cleanup.
- Adds `frontend/src/components/live-log.ts` — a self-contained scrolling log widget with empty state, auto-scroll-to-bottom (unless user has scrolled up), and a `clear()` method.
- Updates `issue-inspector.ts` to mount the live-log panel above the "Activity" section when an issue is `running` or `retrying`, subscribe to events per loaded identifier, and unsubscribe on `destroy()` and `load()` transitions.
- Adds `tests/frontend/event-source.test.ts` with 4 unit tests covering identifier filtering and unsubscribe behaviour.

## Test plan

- [ ] `npm run build && npm run lint && npm run format:check && npm test` all pass (verified locally: 1505 tests pass).
- [ ] Open an issue in `running` or `retrying` state — "Live log" section appears above "Activity".
- [ ] Live agent events stream into the panel in real time; auto-scroll works.
- [ ] Panel disappears on next poll once issue leaves running/retrying state.
- [ ] Navigating away (destroy) does not leak event listeners.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
