### PR TITLE
feat(tracker): GitHub Issues adapter (#11)

### DIFF
--- a/src/agent-runner/docker-session.ts
+++ b/src/agent-runner/docker-session.ts
@@ -35,7 +35,7 @@ export interface DockerSessionDeps {
   archiveDir?: string;
   pathRegistry?: PathRegistry;
   githubToolClient?: GithubApiToolClient;
-  linearClient: LinearClient;
+  linearClient: LinearClient | null;
   logger: SymphonyLogger;
   spawnProcess?: typeof spawn;
 }

--- a/src/agent-runner/index.ts
+++ b/src/agent-runner/index.ts
@@ -26,7 +26,7 @@ export class AgentRunner {
     private readonly deps: {
       getConfig: () => ServiceConfig;
       tracker: TrackerPort;
-      linearClient: LinearClient;
+      linearClient: LinearClient | null;
       workspaceManager: WorkspaceManager;
       archiveDir?: string;
       pathRegistry?: PathRegistry;

--- a/src/agent/codex-request-handler.ts
+++ b/src/agent/codex-request-handler.ts
@@ -26,13 +26,16 @@ function toolErrorResponse(errorMessage: string): CodexRequestResult {
 
 async function handleToolCall(
   params: Record<string, unknown>,
-  linearClient: LinearClient,
+  linearClient: LinearClient | null,
   githubToolClient?: GithubApiToolClient,
 ): Promise<CodexRequestResult> {
   const toolName = asString(params.name) ?? asString(params.toolName);
   const toolArgs = params.arguments ?? params.args ?? params.input ?? null;
 
   if (toolName === "linear_graphql") {
+    if (!linearClient) {
+      return toolErrorResponse("linear_graphql is not available: tracker is not configured for Linear");
+    }
     const response = await handleLinearGraphqlToolCall(linearClient, toolArgs);
     return { response, fatalFailure: null };
   }
@@ -48,7 +51,7 @@ async function handleToolCall(
 
 export async function handleCodexRequest(
   request: JsonRpcRequest,
-  linearClient: LinearClient,
+  linearClient: LinearClient | null,
   githubToolClient?: GithubApiToolClient,
 ): Promise<CodexRequestResult> {
   switch (request.method) {

--- a/src/config/builders.ts
+++ b/src/config/builders.ts
@@ -44,6 +44,8 @@ function deriveTrackerConfig(
     endpoint: resolveConfigString(tracker.endpoint, secretResolver) || "https://api.linear.app/graphql",
     projectSlug:
       resolveConfigString(tracker.project_slug, secretResolver) || secretResolver?.("LINEAR_PROJECT_SLUG") || null,
+    owner: asString(tracker.owner, "") || (secretResolver?.("GITHUB_OWNER") ?? ""),
+    repo: asString(tracker.repo, "") || (secretResolver?.("GITHUB_REPO") ?? ""),
     activeStates: asStringArray(tracker.active_states, DEFAULT_ACTIVE_STATES),
     terminalStates: asStringArray(tracker.terminal_states, DEFAULT_TERMINAL_STATES),
   };

--- a/src/config/schemas/tracker.ts
+++ b/src/config/schemas/tracker.ts
@@ -10,6 +10,8 @@ export const trackerConfigSchema = z.object({
   apiKey: z.string().default(""),
   endpoint: z.string().default("https://api.linear.app/graphql"),
   projectSlug: z.string().nullable().default(null),
+  owner: z.string().default(""),
+  repo: z.string().default(""),
   activeStates: z.array(z.string()).default(DEFAULT_ACTIVE_STATES),
   terminalStates: z.array(z.string()).default(DEFAULT_TERMINAL_STATES),
 });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -195,6 +195,8 @@ export interface TrackerConfig {
   apiKey: string;
   endpoint: string;
   projectSlug: string | null;
+  owner?: string;
+  repo?: string;
   activeStates: string[];
   terminalStates: string[];
 }

--- a/src/dispatch/factory.ts
+++ b/src/dispatch/factory.ts
@@ -14,7 +14,7 @@ import type { RunAttemptDispatcher } from "./types.js";
  */
 export interface DispatcherFactoryDeps {
   tracker: TrackerPort;
-  linearClient: LinearClient;
+  linearClient: LinearClient | null;
   workspaceManager: WorkspaceManager;
   archiveDir: string;
   pathRegistry: PathRegistry;

--- a/src/github/issues-client.ts
+++ b/src/github/issues-client.ts
@@ -1,0 +1,222 @@
+import { randomInt } from "node:crypto";
+import type { Issue, ServiceConfig, SymphonyLogger } from "../core/types.js";
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+type GitHubErrorCode = "github_transport_error" | "github_http_error" | "github_unknown_payload";
+
+export class GitHubIssuesClientError extends Error {
+  constructor(
+    readonly code: GitHubErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "GitHubIssuesClientError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Raw GitHub API shape
+// ---------------------------------------------------------------------------
+
+export interface RawGitHubIssue {
+  number: number;
+  title: string;
+  body: string | null;
+  state: "open" | "closed";
+  labels: { name: string }[];
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Issue normalizer (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a raw GitHub API issue to Symphony's canonical {@link Issue} shape.
+ * State is determined by the first label that matches an active or terminal
+ * state name; falls back to `"open"` when no state label is found.
+ */
+export function normalizeGitHubIssue(
+  raw: RawGitHubIssue,
+  owner: string,
+  repo: string,
+  activeStates: string[],
+  terminalStates: string[],
+): Issue {
+  const allStates = new Set([...activeStates, ...terminalStates]);
+  const labelNames = raw.labels.map((l) => l.name);
+  const stateLabel = labelNames.find((name) => allStates.has(name));
+
+  return {
+    id: String(raw.number),
+    identifier: `${owner}/${repo}#${raw.number}`,
+    title: raw.title,
+    description: raw.body ?? null,
+    priority: null,
+    state: stateLabel ?? "open",
+    branchName: null,
+    url: raw.html_url ?? null,
+    labels: labelNames,
+    blockedBy: [],
+    createdAt: raw.created_at ?? null,
+    updatedAt: raw.updated_at ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+export class GitHubIssuesClient {
+  constructor(
+    private readonly getConfig: () => ServiceConfig,
+    private readonly logger: SymphonyLogger,
+  ) {}
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private getOwnerRepo(): { owner: string; repo: string } {
+    const config = this.getConfig();
+    return {
+      owner: config.tracker.owner ?? "",
+      repo: config.tracker.repo ?? "",
+    };
+  }
+
+  private getToken(): string {
+    const config = this.getConfig();
+    return config.github?.token ?? process.env.GITHUB_TOKEN ?? "";
+  }
+
+  private getApiBaseUrl(): string {
+    const config = this.getConfig();
+    return config.tracker.endpoint || "https://api.github.com";
+  }
+
+  private async request<T>(path: string, options?: RequestInit): Promise<T> {
+    const url = `${this.getApiBaseUrl()}${path}`;
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        ...options,
+        headers: {
+          Authorization: `Bearer ${this.getToken()}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "Content-Type": "application/json",
+          ...(options?.headers ?? {}),
+        },
+      });
+    } catch (error) {
+      this.logger.error({ error: String(error), url }, "github api transport failed");
+      throw new GitHubIssuesClientError("github_transport_error", "github api request failed during transport", {
+        cause: error,
+      });
+    }
+
+    if (!response.ok) {
+      this.logger.error({ status: response.status, statusText: response.statusText, url }, "github api request failed");
+      throw new GitHubIssuesClientError(
+        "github_http_error",
+        `github api request failed with status ${response.status}`,
+      );
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    try {
+      return (await response.json()) as T;
+    } catch (error) {
+      throw new GitHubIssuesClientError("github_unknown_payload", "github api response body is not valid json", {
+        cause: error,
+      });
+    }
+  }
+
+  async withRetry(operation: string, fn: () => Promise<void>): Promise<void> {
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await fn();
+        return;
+      } catch (error) {
+        if (attempt === maxAttempts) {
+          this.logger.warn(
+            { operation, attempt, error: String(error) },
+            "github write-back failed after max retries (non-fatal)",
+          );
+          return;
+        }
+        const delayMs = 1000 * 2 ** (attempt - 1) * (randomInt(500, 1000) / 1000);
+        this.logger.warn({ operation, attempt, delayMs, error: String(error) }, "github write-back retry");
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  async fetchOpenIssues(labels?: string[]): Promise<RawGitHubIssue[]> {
+    const { owner, repo } = this.getOwnerRepo();
+    const labelParam = labels && labels.length > 0 ? `&labels=${encodeURIComponent(labels.join(","))}` : "";
+    return this.request<RawGitHubIssue[]>(`/repos/${owner}/${repo}/issues?state=open&per_page=100${labelParam}`);
+  }
+
+  async fetchIssuesByNumbers(numbers: number[]): Promise<RawGitHubIssue[]> {
+    const { owner, repo } = this.getOwnerRepo();
+    return Promise.all(
+      numbers.map((number) => this.request<RawGitHubIssue>(`/repos/${owner}/${repo}/issues/${number}`)),
+    );
+  }
+
+  async addLabel(issueNumber: number, label: string): Promise<void> {
+    const { owner, repo } = this.getOwnerRepo();
+    await this.request<unknown>(`/repos/${owner}/${repo}/issues/${issueNumber}/labels`, {
+      method: "POST",
+      body: JSON.stringify({ labels: [label] }),
+    });
+  }
+
+  async removeLabel(issueNumber: number, label: string): Promise<void> {
+    const { owner, repo } = this.getOwnerRepo();
+    await this.request<unknown>(`/repos/${owner}/${repo}/issues/${issueNumber}/labels/${encodeURIComponent(label)}`, {
+      method: "DELETE",
+    });
+  }
+
+  async closeIssue(issueNumber: number): Promise<void> {
+    const { owner, repo } = this.getOwnerRepo();
+    await this.request<unknown>(`/repos/${owner}/${repo}/issues/${issueNumber}`, {
+      method: "PATCH",
+      body: JSON.stringify({ state: "closed" }),
+    });
+  }
+
+  async reopenIssue(issueNumber: number): Promise<void> {
+    const { owner, repo } = this.getOwnerRepo();
+    await this.request<unknown>(`/repos/${owner}/${repo}/issues/${issueNumber}`, {
+      method: "PATCH",
+      body: JSON.stringify({ state: "open" }),
+    });
+  }
+
+  async createComment(issueNumber: number, body: string): Promise<void> {
+    const { owner, repo } = this.getOwnerRepo();
+    await this.request<unknown>(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+      method: "POST",
+      body: JSON.stringify({ body }),
+    });
+  }
+}

--- a/src/tracker/factory.ts
+++ b/src/tracker/factory.ts
@@ -1,23 +1,35 @@
 import type { ServiceConfig, SymphonyLogger } from "../core/types.js";
+import { GitHubIssuesClient } from "../github/issues-client.js";
 import { LinearClient } from "../linear/client.js";
+import { GitHubTrackerAdapter } from "./github-adapter.js";
 import { LinearTrackerAdapter } from "./linear-adapter.js";
 import type { TrackerPort } from "./port.js";
 
 /**
  * Result of tracker factory — exposes both the abstract port (for orchestration)
  * and the concrete LinearClient (for MCP GraphQL tool / direct API calls).
+ * `linearClient` is null when the tracker kind is not "linear".
  */
 export interface TrackerFactoryResult {
   tracker: TrackerPort;
-  linearClient: LinearClient;
+  linearClient: LinearClient | null;
 }
 
 /**
  * Creates the tracker subsystem from service config.
- * Encapsulates LinearClient instantiation and adapter wrapping so that
+ * Supports "linear" (default) and "github" tracker kinds.
+ * Encapsulates client instantiation and adapter wrapping so that
  * `services.ts` does not depend on tracker internals.
  */
 export function createTracker(getConfig: () => ServiceConfig, logger: SymphonyLogger): TrackerFactoryResult {
+  const config = getConfig();
+
+  if (config.tracker.kind === "github") {
+    const client = new GitHubIssuesClient(getConfig, logger.child({ component: "github" }));
+    const tracker = new GitHubTrackerAdapter(client, getConfig);
+    return { tracker, linearClient: null };
+  }
+
   const linearClient = new LinearClient(getConfig, logger.child({ component: "linear" }));
   const tracker = new LinearTrackerAdapter(linearClient);
   return { tracker, linearClient };

--- a/src/tracker/github-adapter.ts
+++ b/src/tracker/github-adapter.ts
@@ -1,0 +1,66 @@
+import type { Issue, ServiceConfig } from "../core/types.js";
+import { GitHubIssuesClient, normalizeGitHubIssue } from "../github/issues-client.js";
+import type { TrackerPort } from "./port.js";
+
+/**
+ * Thin adapter that implements TrackerPort by delegating to GitHubIssuesClient.
+ * GitHub uses label names as state identifiers — there are no separate "state IDs".
+ */
+export class GitHubTrackerAdapter implements TrackerPort {
+  constructor(
+    private readonly client: GitHubIssuesClient,
+    private readonly getConfig: () => ServiceConfig,
+  ) {}
+
+  async fetchCandidateIssues(): Promise<Issue[]> {
+    const config = this.getConfig();
+    const { owner, repo, activeStates, terminalStates } = config.tracker;
+    const open = await this.client.fetchOpenIssues();
+    return open.map((r) => normalizeGitHubIssue(r, owner ?? "", repo ?? "", activeStates, terminalStates));
+  }
+
+  async fetchIssueStatesByIds(ids: string[]): Promise<Issue[]> {
+    const config = this.getConfig();
+    const { owner, repo, activeStates, terminalStates } = config.tracker;
+    const numbers = ids.map((id) => Number(id)).filter((n) => !Number.isNaN(n));
+    const raw = await this.client.fetchIssuesByNumbers(numbers);
+    return raw.map((r) => normalizeGitHubIssue(r, owner ?? "", repo ?? "", activeStates, terminalStates));
+  }
+
+  async fetchIssuesByStates(states: string[]): Promise<Issue[]> {
+    const config = this.getConfig();
+    const { owner, repo, activeStates, terminalStates } = config.tracker;
+    const raw = await this.client.fetchOpenIssues(states);
+    return raw.map((r) => normalizeGitHubIssue(r, owner ?? "", repo ?? "", activeStates, terminalStates));
+  }
+
+  async resolveStateId(stateName: string): Promise<string | null> {
+    // GitHub uses label names directly as state IDs — no resolution needed.
+    return stateName || null;
+  }
+
+  async updateIssueState(issueId: string, stateId: string): Promise<void> {
+    const number = Number(issueId);
+    const config = this.getConfig();
+    const isTerminal = config.tracker.terminalStates.includes(stateId);
+    await this.client.withRetry("addLabel", () => this.client.addLabel(number, stateId));
+    if (isTerminal) {
+      await this.client.withRetry("closeIssue", () => this.client.closeIssue(number));
+    } else {
+      await this.client.withRetry("reopenIssue", () => this.client.reopenIssue(number));
+    }
+  }
+
+  async createComment(issueId: string, body: string): Promise<void> {
+    await this.client.withRetry("createComment", () => this.client.createComment(Number(issueId), body));
+  }
+
+  async transitionIssue(issueId: string, stateId: string): Promise<{ success: boolean }> {
+    try {
+      await this.updateIssueState(issueId, stateId);
+      return { success: true };
+    } catch {
+      return { success: false };
+    }
+  }
+}

--- a/tests/github/issues-client.test.ts
+++ b/tests/github/issues-client.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GitHubIssuesClient, GitHubIssuesClientError, normalizeGitHubIssue } from "../../src/github/issues-client.js";
+import { createJsonResponse, createMockLogger } from "../helpers.js";
+import type { ServiceConfig } from "../../src/core/types.js";
+import type { RawGitHubIssue } from "../../src/github/issues-client.js";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function createConfig(): ServiceConfig {
+  return {
+    tracker: {
+      kind: "github",
+      apiKey: "",
+      endpoint: "https://api.github.com",
+      projectSlug: null,
+      owner: "acme",
+      repo: "awesome",
+      activeStates: ["in-progress"],
+      terminalStates: ["done", "cancelled"],
+    },
+    github: { token: "gh-token", apiBaseUrl: "https://api.github.com" },
+    polling: { intervalMs: 1000 },
+    workspace: {
+      root: "/tmp/symphony",
+      strategy: "directory",
+      branchPrefix: "symphony/",
+      hooks: { afterCreate: null, beforeRun: null, afterRun: null, beforeRemove: null, timeoutMs: 1000 },
+    },
+    agent: {
+      maxConcurrentAgents: 1,
+      maxConcurrentAgentsByState: {},
+      maxTurns: 2,
+      maxRetryBackoffMs: 10000,
+      maxContinuationAttempts: 1,
+      successState: null,
+      stallTimeoutMs: 0,
+    },
+    codex: {
+      command: "codex app-server",
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+      approvalPolicy: "never",
+      threadSandbox: "danger-full-access",
+      turnSandboxPolicy: { type: "dangerFullAccess" },
+      readTimeoutMs: 1000,
+      turnTimeoutMs: 1000,
+      drainTimeoutMs: 0,
+      startupTimeoutMs: 0,
+      stallTimeoutMs: 0,
+      auth: { mode: "api_key", sourceHome: "/tmp/auth" },
+      provider: null,
+      sandbox: {
+        image: "symphony-codex:latest",
+        network: "",
+        security: { noNewPrivileges: true, dropCapabilities: true, gvisor: false, seccompProfile: "" },
+        resources: { memory: "4g", memoryReservation: "1g", memorySwap: "4g", cpus: "2.0", tmpfsSize: "512m" },
+        extraMounts: [],
+        envPassthrough: [],
+        logs: { driver: "json-file", maxSize: "50m", maxFile: 3 },
+        egressAllowlist: [],
+      },
+    },
+    server: { port: 4000 },
+    repos: [],
+  } as unknown as ServiceConfig;
+}
+
+function makeRawIssue(overrides: Partial<RawGitHubIssue> = {}): RawGitHubIssue {
+  return {
+    number: 42,
+    title: "Fix the bug",
+    body: "Details here",
+    state: "open",
+    labels: [{ name: "in-progress" }],
+    html_url: "https://github.com/acme/awesome/issues/42",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-02T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// normalizeGitHubIssue unit tests
+// ---------------------------------------------------------------------------
+
+describe("normalizeGitHubIssue", () => {
+  const active = ["in-progress", "review"];
+  const terminal = ["done", "cancelled"];
+
+  it("maps an active state label correctly", () => {
+    const raw = makeRawIssue({ labels: [{ name: "in-progress" }] });
+    const issue = normalizeGitHubIssue(raw, "acme", "awesome", active, terminal);
+    expect(issue.state).toBe("in-progress");
+    expect(issue.id).toBe("42");
+    expect(issue.identifier).toBe("acme/awesome#42");
+    expect(issue.title).toBe("Fix the bug");
+    expect(issue.url).toBe("https://github.com/acme/awesome/issues/42");
+  });
+
+  it("maps a terminal state label correctly", () => {
+    const raw = makeRawIssue({ labels: [{ name: "done" }] });
+    const issue = normalizeGitHubIssue(raw, "acme", "awesome", active, terminal);
+    expect(issue.state).toBe("done");
+  });
+
+  it("falls back to 'open' when no state label matches", () => {
+    const raw = makeRawIssue({ labels: [{ name: "bug" }, { name: "feature" }] });
+    const issue = normalizeGitHubIssue(raw, "acme", "awesome", active, terminal);
+    expect(issue.state).toBe("open");
+  });
+
+  it("includes all labels in the labels array", () => {
+    const raw = makeRawIssue({ labels: [{ name: "bug" }, { name: "in-progress" }] });
+    const issue = normalizeGitHubIssue(raw, "acme", "awesome", active, terminal);
+    expect(issue.labels).toEqual(["bug", "in-progress"]);
+  });
+
+  it("sets priority to null and blockedBy to empty array", () => {
+    const raw = makeRawIssue();
+    const issue = normalizeGitHubIssue(raw, "acme", "awesome", active, terminal);
+    expect(issue.priority).toBeNull();
+    expect(issue.blockedBy).toEqual([]);
+  });
+
+  it("sets branchName to null", () => {
+    const raw = makeRawIssue();
+    const issue = normalizeGitHubIssue(raw, "acme", "awesome", active, terminal);
+    expect(issue.branchName).toBeNull();
+  });
+
+  it("handles null body gracefully", () => {
+    const raw = makeRawIssue({ body: null });
+    const issue = normalizeGitHubIssue(raw, "acme", "awesome", active, terminal);
+    expect(issue.description).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GitHubIssuesClient tests
+// ---------------------------------------------------------------------------
+
+describe("GitHubIssuesClient", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function createClient(): GitHubIssuesClient {
+    const logger = createMockLogger();
+    return new GitHubIssuesClient(() => createConfig(), logger);
+  }
+
+  it("fetchOpenIssues calls the correct URL", async () => {
+    const issues = [makeRawIssue()];
+    fetchMock.mockResolvedValue(createJsonResponse(200, issues));
+
+    const client = createClient();
+    const result = await client.fetchOpenIssues();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("/repos/acme/awesome/issues");
+    expect(url).toContain("state=open");
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(42);
+  });
+
+  it("fetchOpenIssues includes labels param when provided", async () => {
+    fetchMock.mockResolvedValue(createJsonResponse(200, []));
+
+    const client = createClient();
+    await client.fetchOpenIssues(["in-progress", "review"]);
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("labels=");
+  });
+
+  it("throws GitHubIssuesClientError on HTTP error", async () => {
+    fetchMock.mockResolvedValue(createJsonResponse(401, { message: "Unauthorized" }));
+
+    const client = createClient();
+    await expect(client.fetchOpenIssues()).rejects.toThrow(GitHubIssuesClientError);
+  });
+
+  it("throws GitHubIssuesClientError with github_http_error code on non-ok response", async () => {
+    fetchMock.mockResolvedValue(createJsonResponse(403, { message: "Forbidden" }));
+
+    const client = createClient();
+    try {
+      await client.fetchOpenIssues();
+    } catch (error) {
+      expect(error).toBeInstanceOf(GitHubIssuesClientError);
+      expect((error as GitHubIssuesClientError).code).toBe("github_http_error");
+    }
+  });
+
+  it("throws GitHubIssuesClientError with github_transport_error on network failure", async () => {
+    fetchMock.mockRejectedValue(new Error("network unreachable"));
+
+    const client = createClient();
+    try {
+      await client.fetchOpenIssues();
+    } catch (error) {
+      expect(error).toBeInstanceOf(GitHubIssuesClientError);
+      expect((error as GitHubIssuesClientError).code).toBe("github_transport_error");
+    }
+  });
+
+  it("fetchIssuesByNumbers fetches each issue in parallel", async () => {
+    const issue1 = makeRawIssue({ number: 1 });
+    const issue2 = makeRawIssue({ number: 2 });
+    fetchMock
+      .mockResolvedValueOnce(createJsonResponse(200, issue1))
+      .mockResolvedValueOnce(createJsonResponse(200, issue2));
+
+    const client = createClient();
+    const result = await client.fetchIssuesByNumbers([1, 2]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(2);
+  });
+});

--- a/tests/tracker/github-adapter.test.ts
+++ b/tests/tracker/github-adapter.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { GitHubTrackerAdapter } from "../../src/tracker/github-adapter.js";
+import type { GitHubIssuesClient } from "../../src/github/issues-client.js";
+import type { ServiceConfig } from "../../src/core/types.js";
+import type { RawGitHubIssue } from "../../src/github/issues-client.js";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function createConfig(): ServiceConfig {
+  return {
+    tracker: {
+      kind: "github",
+      apiKey: "",
+      endpoint: "https://api.github.com",
+      projectSlug: null,
+      owner: "acme",
+      repo: "awesome",
+      activeStates: ["in-progress"],
+      terminalStates: ["done"],
+    },
+    github: { token: "gh-token", apiBaseUrl: "https://api.github.com" },
+    polling: { intervalMs: 1000 },
+    workspace: {
+      root: "/tmp/symphony",
+      strategy: "directory",
+      branchPrefix: "symphony/",
+      hooks: { afterCreate: null, beforeRun: null, afterRun: null, beforeRemove: null, timeoutMs: 1000 },
+    },
+    agent: {
+      maxConcurrentAgents: 1,
+      maxConcurrentAgentsByState: {},
+      maxTurns: 2,
+      maxRetryBackoffMs: 10000,
+      maxContinuationAttempts: 1,
+      successState: null,
+      stallTimeoutMs: 0,
+    },
+    codex: {
+      command: "codex app-server",
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+      approvalPolicy: "never",
+      threadSandbox: "danger-full-access",
+      turnSandboxPolicy: { type: "dangerFullAccess" },
+      readTimeoutMs: 1000,
+      turnTimeoutMs: 1000,
+      drainTimeoutMs: 0,
+      startupTimeoutMs: 0,
+      stallTimeoutMs: 0,
+      auth: { mode: "api_key", sourceHome: "/tmp/auth" },
+      provider: null,
+      sandbox: {
+        image: "symphony-codex:latest",
+        network: "",
+        security: { noNewPrivileges: true, dropCapabilities: true, gvisor: false, seccompProfile: "" },
+        resources: { memory: "4g", memoryReservation: "1g", memorySwap: "4g", cpus: "2.0", tmpfsSize: "512m" },
+        extraMounts: [],
+        envPassthrough: [],
+        logs: { driver: "json-file", maxSize: "50m", maxFile: 3 },
+        egressAllowlist: [],
+      },
+    },
+    server: { port: 4000 },
+    repos: [],
+  } as unknown as ServiceConfig;
+}
+
+function makeRawIssue(overrides: Partial<RawGitHubIssue> = {}): RawGitHubIssue {
+  return {
+    number: 7,
+    title: "Sample issue",
+    body: "Body text",
+    state: "open",
+    labels: [{ name: "in-progress" }],
+    html_url: "https://github.com/acme/awesome/issues/7",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-02T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock client factory
+// ---------------------------------------------------------------------------
+
+function createMockClient(): GitHubIssuesClient {
+  return {
+    fetchOpenIssues: vi.fn().mockResolvedValue([]),
+    fetchIssuesByNumbers: vi.fn().mockResolvedValue([]),
+    addLabel: vi.fn().mockResolvedValue(undefined),
+    removeLabel: vi.fn().mockResolvedValue(undefined),
+    closeIssue: vi.fn().mockResolvedValue(undefined),
+    reopenIssue: vi.fn().mockResolvedValue(undefined),
+    createComment: vi.fn().mockResolvedValue(undefined),
+    withRetry: vi.fn().mockImplementation((_op: string, fn: () => Promise<void>) => fn()),
+  } as unknown as GitHubIssuesClient;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GitHubTrackerAdapter", () => {
+  let client: GitHubIssuesClient;
+  let adapter: GitHubTrackerAdapter;
+
+  beforeEach(() => {
+    client = createMockClient();
+    adapter = new GitHubTrackerAdapter(client, createConfig);
+  });
+
+  describe("fetchCandidateIssues", () => {
+    it("returns normalized issues from fetchOpenIssues", async () => {
+      vi.mocked(client.fetchOpenIssues).mockResolvedValue([makeRawIssue()]);
+
+      const issues = await adapter.fetchCandidateIssues();
+
+      expect(issues).toHaveLength(1);
+      expect(issues[0].id).toBe("7");
+      expect(issues[0].identifier).toBe("acme/awesome#7");
+      expect(issues[0].state).toBe("in-progress");
+    });
+
+    it("returns empty array when no open issues", async () => {
+      vi.mocked(client.fetchOpenIssues).mockResolvedValue([]);
+
+      const issues = await adapter.fetchCandidateIssues();
+
+      expect(issues).toHaveLength(0);
+    });
+  });
+
+  describe("fetchIssueStatesByIds", () => {
+    it("fetches issues by number and normalizes them", async () => {
+      vi.mocked(client.fetchIssuesByNumbers).mockResolvedValue([makeRawIssue({ number: 7 })]);
+
+      const issues = await adapter.fetchIssueStatesByIds(["7"]);
+
+      expect(client.fetchIssuesByNumbers).toHaveBeenCalledWith([7]);
+      expect(issues).toHaveLength(1);
+      expect(issues[0].id).toBe("7");
+    });
+
+    it("filters out non-numeric ids", async () => {
+      vi.mocked(client.fetchIssuesByNumbers).mockResolvedValue([]);
+
+      await adapter.fetchIssueStatesByIds(["not-a-number", "7"]);
+
+      expect(client.fetchIssuesByNumbers).toHaveBeenCalledWith([7]);
+    });
+  });
+
+  describe("fetchIssuesByStates", () => {
+    it("calls fetchOpenIssues with the given state labels", async () => {
+      vi.mocked(client.fetchOpenIssues).mockResolvedValue([makeRawIssue()]);
+
+      await adapter.fetchIssuesByStates(["in-progress"]);
+
+      expect(client.fetchOpenIssues).toHaveBeenCalledWith(["in-progress"]);
+    });
+  });
+
+  describe("resolveStateId", () => {
+    it("returns the label name as-is", async () => {
+      const result = await adapter.resolveStateId("in-progress");
+      expect(result).toBe("in-progress");
+    });
+
+    it("returns null for an empty string", async () => {
+      const result = await adapter.resolveStateId("");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("createComment", () => {
+    it("delegates to client.createComment via withRetry", async () => {
+      await adapter.createComment("7", "Hello world");
+
+      expect(client.withRetry).toHaveBeenCalledWith("createComment", expect.any(Function));
+    });
+  });
+
+  describe("transitionIssue", () => {
+    it("returns { success: true } on successful state update", async () => {
+      const result = await adapter.transitionIssue("7", "done");
+
+      expect(result).toEqual({ success: true });
+    });
+
+    it("returns { success: false } when an error is thrown", async () => {
+      vi.mocked(client.withRetry).mockRejectedValue(new Error("API error"));
+
+      const result = await adapter.transitionIssue("7", "done");
+
+      expect(result).toEqual({ success: false });
+    });
+  });
+
+  describe("updateIssueState", () => {
+    it("adds the new state label", async () => {
+      await adapter.updateIssueState("7", "in-progress");
+
+      expect(client.withRetry).toHaveBeenCalledWith("addLabel", expect.any(Function));
+    });
+
+    it("closes the issue when transitioning to a terminal state", async () => {
+      // Capture which operations are called
+      const ops: string[] = [];
+      vi.mocked(client.withRetry).mockImplementation((op: string, fn: () => Promise<void>) => {
+        ops.push(op);
+        return fn();
+      });
+
+      await adapter.updateIssueState("7", "done");
+
+      expect(ops).toContain("addLabel");
+      expect(ops).toContain("closeIssue");
+    });
+
+    it("reopens the issue when transitioning to an active state", async () => {
+      const ops: string[] = [];
+      vi.mocked(client.withRetry).mockImplementation((op: string, fn: () => Promise<void>) => {
+        ops.push(op);
+        return fn();
+      });
+
+      await adapter.updateIssueState("7", "in-progress");
+
+      expect(ops).toContain("addLabel");
+      expect(ops).toContain("reopenIssue");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `GitHubIssuesClient` (`src/github/issues-client.ts`) — REST API v3 client with exponential-backoff retry, `GitHubIssuesClientError`, and `normalizeGitHubIssue` for mapping raw GitHub issues to Symphony's `Issue` shape
- Add `GitHubTrackerAdapter` (`src/tracker/github-adapter.ts`) — thin `TrackerPort` implementation that delegates to `GitHubIssuesClient`; uses label names as state IDs, closes/reopens issues on terminal/active transitions
- Update `createTracker` factory to route `kind: "github"` to the new adapter; `linearClient` is now `LinearClient | null` (null when using GitHub)
- Extend `TrackerConfig`, Zod schema, and `deriveTrackerConfig` with `owner` and `repo` fields (populated from config or `GITHUB_OWNER`/`GITHUB_REPO` env vars)
- Guard `linear_graphql` tool in `codex-request-handler` to return a graceful error when `linearClient` is null

## Test plan

- [ ] `tests/github/issues-client.test.ts` — `normalizeGitHubIssue` state mapping, fallback to `"open"`, `fetchOpenIssues` URL construction, HTTP/transport error paths
- [ ] `tests/tracker/github-adapter.test.ts` — `fetchCandidateIssues`, `fetchIssueStatesByIds`, `fetchIssuesByStates`, `resolveStateId`, `createComment`, `transitionIssue` success/failure, `updateIssueState` close/reopen paths
- [ ] `npm run build && npm run lint && npm run format:check && npm test && npm run knip` — all green (141 files, 1527 tests)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
