### PR TITLE
feat(dashboard): cost tracking UI — overview panel, attempts table, issue inspector

### DIFF
--- a/frontend/src/components/attempts-table.ts
+++ b/frontend/src/components/attempts-table.ts
@@ -7,7 +7,7 @@ import {
   createTableHead,
   setTableCellLabel,
 } from "../ui/table";
-import { formatDuration, formatShortTime, formatTokenUsage } from "../utils/format";
+import { formatCostUsd, formatDuration, formatShortTime, formatTokenUsage } from "../utils/format";
 
 function durationForAttempt(attempt: AttemptSummary): string {
   if (!attempt.startedAt || !attempt.endedAt) {
@@ -29,11 +29,11 @@ export function createAttemptsTable(attempts: AttemptSummary[], onOpen: (attempt
   wrap.className = "attempts-table-wrap";
   const table = document.createElement("table");
   table.className = "attempts-table";
-  const head = createTableHead(["Run#", "Status", "Start", "End", "Duration", "Model", "Tokens", "Error"]);
+  const head = createTableHead(["Run#", "Status", "Start", "End", "Duration", "Model", "Tokens", "Cost", "Error"]);
   const body = document.createElement("tbody");
 
   if (attempts.length === 0) {
-    body.append(createTableEmptyRow("No attempts yet.", 8));
+    body.append(createTableEmptyRow("No attempts yet.", 9));
   }
 
   attempts.forEach((attempt) => {
@@ -51,8 +51,9 @@ export function createAttemptsTable(attempts: AttemptSummary[], onOpen: (attempt
       createMonoTableCell(formatTokenUsage(attempt.tokenUsage?.totalTokens ?? null)),
       "Tokens",
     );
+    const costCell = setTableCellLabel(createMonoTableCell(formatCostUsd(attempt.costUsd ?? null)), "Cost");
     const errorCell = setTableCellLabel(createErrorCell(attempt), "Error");
-    row.append(runCell, statusCell, startCell, endCell, durationCell, modelCell, tokensCell, errorCell);
+    row.append(runCell, statusCell, startCell, endCell, durationCell, modelCell, tokensCell, costCell, errorCell);
     applyTableRowInteraction(row, () => onOpen(attempt.attemptId), { keyboard: "enter" });
     body.append(row);
   });

--- a/frontend/src/components/issue-inspector-sections.ts
+++ b/frontend/src/components/issue-inspector-sections.ts
@@ -8,7 +8,13 @@ import { createAttemptsTable } from "./attempts-table";
 import { createButton, createField, createSelectControl, createTextInput } from "./forms.js";
 import { createEventRow } from "./event-row";
 import { createEmptyState } from "./empty-state";
-import { computeDurationSeconds, formatCompactNumber, formatDuration, formatTimestamp } from "../utils/format";
+import {
+  computeDurationSeconds,
+  formatCompactNumber,
+  formatCostUsd,
+  formatDuration,
+  formatTimestamp,
+} from "../utils/format";
 import { applyStagger, button, kv } from "./issue-inspector-common.js";
 
 export function buildDescriptionSection(detail: IssueDetail): HTMLElement {
@@ -37,6 +43,14 @@ export function buildDescriptionSection(detail: IssueDetail): HTMLElement {
   return section;
 }
 
+function computeIssueCostUsd(detail: IssueDetail): number | null {
+  const total = detail.attempts.reduce<number | null>((acc, attempt) => {
+    if (attempt.costUsd === null || attempt.costUsd === undefined) return acc;
+    return (acc ?? 0) + attempt.costUsd;
+  }, null);
+  return total;
+}
+
 export function buildWorkspaceSection(detail: IssueDetail): HTMLElement {
   const section = document.createElement("section");
   section.className = "issue-section mc-panel expand-in";
@@ -48,6 +62,7 @@ export function buildWorkspaceSection(detail: IssueDetail): HTMLElement {
     kv("Branch", detail.branchName ?? "—"),
     kv("Pull request", detail.pull_request_url ?? "—"),
     kv("Tokens", formatCompactNumber(detail.tokenUsage?.totalTokens ?? null)),
+    kv("Cost", formatCostUsd(computeIssueCostUsd(detail))),
     kv("Duration", formatDuration(computeDurationSeconds(detail.startedAt, detail.updated_at ?? detail.updatedAt))),
     kv("Last event", formatTimestamp(detail.lastEventAt ?? detail.updated_at ?? detail.updatedAt)),
   );

--- a/frontend/src/pages/overview-view.ts
+++ b/frontend/src/pages/overview-view.ts
@@ -6,7 +6,13 @@ import { createEventRow } from "../components/event-row";
 import { createSystemHealthBadge } from "../components/system-health-badge";
 import { createStallEventsTable } from "../components/stall-events-table";
 import { buildAttentionList, latestTerminalIssues } from "../utils/issues";
-import { formatCompactNumber, formatDuration, formatRateLimitHeadroom, formatRelativeTime } from "../utils/format";
+import {
+  formatCompactNumber,
+  formatCostUsd,
+  formatDuration,
+  formatRateLimitHeadroom,
+  formatRelativeTime,
+} from "../utils/format";
 import { flashDiff, setTextWithDiff } from "../utils/diff";
 import { registerPageCleanup } from "../utils/page";
 
@@ -278,8 +284,9 @@ export function createOverviewPage(): HTMLElement {
   const outputTokens = createLiveMetric("Output");
   const totalTokens = createLiveMetric("Total");
   const runtime = createLiveMetric("Runtime");
+  const cost = createLiveMetric("Cost");
 
-  tokenGrid.append(inputTokens.root, outputTokens.root, totalTokens.root, runtime.root);
+  tokenGrid.append(inputTokens.root, outputTokens.root, totalTokens.root, runtime.root, cost.root);
   tokenSection.append(tokenGrid);
   secondary.append(tokenSection);
 
@@ -387,6 +394,7 @@ export function createOverviewPage(): HTMLElement {
     setTextWithDiff(outputTokens.value, formatCompactNumber(snapshot.codex_totals.output_tokens));
     setTextWithDiff(totalTokens.value, formatCompactNumber(snapshot.codex_totals.total_tokens));
     setTextWithDiff(runtime.value, formatDuration(snapshot.codex_totals.seconds_running));
+    setTextWithDiff(cost.value, formatCostUsd(snapshot.codex_totals.cost_usd));
 
     // Attention list - primary zone
     fillList(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -11,6 +11,7 @@ export interface RuntimeSnapshot {
     output_tokens: number;
     total_tokens: number;
     seconds_running: number;
+    cost_usd: number | null;
   };
   rate_limits: RateLimits | null;
   recent_events: RecentEvent[];
@@ -92,6 +93,7 @@ export interface AttemptSummary {
   model: string | null;
   reasoningEffort: string | null;
   tokenUsage: { inputTokens: number; outputTokens: number; totalTokens: number } | null;
+  costUsd: number | null;
   errorCode: string | null;
   errorMessage: string | null;
 }

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -164,6 +164,17 @@ export function computeDurationSeconds(
   return Math.max(0, Math.round((endDate.getTime() - startDate.getTime()) / 1000));
 }
 
+export function formatCostUsd(usd: number | null | undefined): string {
+  if (usd === null || usd === undefined) {
+    return "—";
+  }
+  return new Intl.NumberFormat("en", {
+    style: "currency",
+    currency: "USD",
+    maximumSignificantDigits: 4,
+  }).format(usd);
+}
+
 export function formatBytes(bytes: number | null | undefined): string {
   if (bytes === null || bytes === undefined || bytes < 0) {
     return "—";

--- a/frontend/src/views/attempt-view.ts
+++ b/frontend/src/views/attempt-view.ts
@@ -4,7 +4,13 @@ import { createPageHeader } from "../components/page-header";
 import { router } from "../router";
 import { skeletonBlock, skeletonCard } from "../ui/skeleton";
 import { statusChip } from "../ui/status-chip";
-import { computeDurationSeconds, formatCompactNumber, formatDuration, formatTimestamp } from "../utils/format";
+import {
+  computeDurationSeconds,
+  formatCompactNumber,
+  formatCostUsd,
+  formatDuration,
+  formatTimestamp,
+} from "../utils/format";
 import { registerPageCleanup } from "../utils/page";
 import type { AttemptRecord, IssueDetail } from "../types";
 import { resolveIssueIdentifier } from "./attempt-utils";
@@ -98,6 +104,7 @@ function renderAttemptPage(attempt: AttemptRecord, issue: IssueDetail | null): H
         : "—",
       true,
     ),
+    createMetaItem("Cost", formatCostUsd(attempt.costUsd ?? null), true),
   );
 
   const workspace = createSection("Workspace / git");

--- a/tests/e2e/mocks/data/attempts.ts
+++ b/tests/e2e/mocks/data/attempts.ts
@@ -7,6 +7,7 @@ export interface AttemptSummary {
   model: string | null;
   reasoningEffort: string | null;
   tokenUsage: { inputTokens: number; outputTokens: number; totalTokens: number } | null;
+  costUsd: number | null;
   errorCode: string | null;
   errorMessage: string | null;
 }
@@ -33,6 +34,7 @@ export function buildAttemptSummary(overrides?: Partial<AttemptSummary>): Attemp
     model: "o3-mini",
     reasoningEffort: "medium",
     tokenUsage: { inputTokens: 5000, outputTokens: 3000, totalTokens: 8000 },
+    costUsd: null,
     errorCode: null,
     errorMessage: null,
     ...overrides,

--- a/tests/e2e/mocks/data/issue-detail.ts
+++ b/tests/e2e/mocks/data/issue-detail.ts
@@ -42,6 +42,7 @@ export interface AttemptSummary {
   model: string | null;
   reasoningEffort: string | null;
   tokenUsage: { inputTokens: number; outputTokens: number; totalTokens: number } | null;
+  costUsd: number | null;
   errorCode: string | null;
   errorMessage: string | null;
 }
@@ -96,6 +97,7 @@ export function buildIssueDetail(overrides?: Partial<IssueDetail>): IssueDetail 
         model: "o3-mini",
         reasoningEffort: "medium",
         tokenUsage: { inputTokens: 5000, outputTokens: 3000, totalTokens: 8000 },
+        costUsd: null,
         errorCode: null,
         errorMessage: null,
       },

--- a/tests/frontend/format.test.ts
+++ b/tests/frontend/format.test.ts
@@ -4,6 +4,7 @@ import {
   computeDurationSeconds,
   formatBytes,
   formatCompactNumber,
+  formatCostUsd,
   formatCountdown,
   formatDuration,
   formatRateLimitHeadroom,
@@ -241,6 +242,33 @@ describe("computeDurationSeconds", () => {
   it("clamps negative duration to zero", () => {
     const result = computeDurationSeconds("2026-03-26T12:05:00Z", "2026-03-26T12:00:00Z");
     expect(result).toBe(0);
+  });
+});
+
+describe("formatCostUsd", () => {
+  it("returns dash for null and undefined", () => {
+    expect(formatCostUsd(null)).toBe("—");
+    expect(formatCostUsd(undefined)).toBe("—");
+  });
+
+  it("formats zero cost as currency", () => {
+    const result = formatCostUsd(0);
+    expect(result).toMatch(/\$0/);
+  });
+
+  it("formats a small fractional cost with up to 4 significant digits", () => {
+    const result = formatCostUsd(0.0023);
+    expect(result).toMatch(/\$0\.0023/);
+  });
+
+  it("formats a dollar-range cost", () => {
+    const result = formatCostUsd(1.25);
+    expect(result).toMatch(/\$1\.25/);
+  });
+
+  it("formats a sub-cent cost with significant digits", () => {
+    const result = formatCostUsd(0.000023);
+    expect(result).toMatch(/\$0\.000023/);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `formatCostUsd(usd: number | null): string` to `frontend/src/utils/format.ts` using `Intl.NumberFormat` with `maximumSignificantDigits: 4` — returns `"—"` for null
- Wires `cost_usd` from `codex_totals` into the overview page "Token burn" panel as a live "Cost" metric pill
- Adds a "Cost" column to the attempts table after "Tokens", showing per-attempt cost from `attempt.costUsd`
- Adds a "Cost" kv row in the issue inspector "Workspace & git" section, computed by summing `costUsd` across all attempts for that issue
- Adds a "Cost" meta-item to the attempt-view summary strip
- Updates `frontend/src/types.ts`: adds `cost_usd: number | null` to `RuntimeSnapshot["codex_totals"]` and `costUsd: number | null` to `AttemptSummary`
- Updates E2E mock data factories (`tests/e2e/mocks/data/attempts.ts`, `issue-detail.ts`) to include `costUsd: null`
- Adds `formatCostUsd` unit tests in `tests/frontend/format.test.ts`

## Test plan

- [x] `npm run build` — TypeScript + Vite compilation passes
- [x] `npm run lint` — ESLint passes (no new errors)
- [x] `npm run format:check` — Prettier formatting clean
- [x] `npm test` — 143 test files, 1554 tests passing (includes new `formatCostUsd` tests)
- [ ] Visual check: load dashboard, verify "Cost" appears in the Token burn panel
- [ ] Navigate to an issue inspector, verify "Cost" row in Workspace & git section
- [ ] Open an attempt detail, verify "Cost" in summary strip
- [ ] Open the issue inspector attempts table, verify "Cost" column
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
