### PR TITLE
feat(settings): add modified badges, inline validation, and ARIA hints

### DIFF
--- a/frontend/src/styles/settings.css
+++ b/frontend/src/styles/settings.css
@@ -107,6 +107,23 @@
   -webkit-box-orient: vertical;
 }
 
+/* ── Modified/Unsaved badges ───────────────────────────── */
+.settings-nav-badge-modified,
+.settings-nav-badge-unsaved {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.settings-nav-badge-modified {
+  background: var(--interactive-primary);
+}
+
+.settings-nav-badge-unsaved {
+  background: var(--status-caution, #d97706);
+}
+
 .settings-nav-separator {
   height: 1px;
   background: var(--border-subtle, #e2e8f0);
@@ -421,6 +438,21 @@
   color: var(--status-blocked);
   font-size: var(--text-sm);
   margin-bottom: var(--space-4);
+}
+
+/* ── Inline validation errors ──────────────────────────── */
+.settings-field-error {
+  border-color: var(--status-blocked) !important;
+}
+
+.settings-field-error-text {
+  color: var(--status-blocked);
+  font-size: var(--text-xs);
+  margin-top: var(--space-1);
+}
+
+.settings-field-error-text[hidden] {
+  display: none;
 }
 
 .settings-stack {

--- a/frontend/src/views/settings-forms.ts
+++ b/frontend/src/views/settings-forms.ts
@@ -10,6 +10,7 @@ import type { SettingsFieldDefinition } from "./settings-helpers";
 
 interface SettingsFieldRenderOptions {
   value: string;
+  hintId?: string;
   onInput: (value: string) => void;
   onFocus: () => void;
   onAction?: () => void;
@@ -19,6 +20,22 @@ export function createSettingsField(field: SettingsFieldDefinition, options: Set
   const control = buildControl(field, options);
   const wrapper = createField({ label: field.label, hint: field.hint }, control);
   wrapper.dataset.fieldKind = field.kind;
+
+  if (options.hintId) {
+    const hintEl = wrapper.querySelector(".form-hint");
+    const oldHintId = hintEl?.id;
+    if (hintEl) {
+      hintEl.id = options.hintId;
+    }
+    const fieldControl = wrapper.querySelector("input, textarea, select");
+    if (fieldControl) {
+      const existing = fieldControl.getAttribute("aria-describedby") ?? "";
+      const ids = existing ? existing.split(" ").filter((id) => id !== oldHintId) : [];
+      ids.unshift(options.hintId);
+      fieldControl.setAttribute("aria-describedby", ids.join(" "));
+    }
+  }
+
   return wrapper;
 }
 
@@ -139,6 +156,35 @@ function buildControl(field: SettingsFieldDefinition, options: SettingsFieldRend
     });
     textarea.addEventListener("input", () => options.onInput(textarea.value));
     textarea.addEventListener("focus", options.onFocus);
+
+    if (field.kind === "json") {
+      const errorEl = createInlineError();
+      textarea.addEventListener("blur", () => {
+        const val = textarea.value.trim();
+        if (val === "") {
+          textarea.classList.remove("settings-field-error");
+          errorEl.hidden = true;
+          return;
+        }
+        try {
+          JSON.parse(val);
+          textarea.classList.remove("settings-field-error");
+          errorEl.hidden = true;
+        } catch (error_) {
+          textarea.classList.add("settings-field-error");
+          errorEl.textContent = `Invalid JSON: ${error_ instanceof SyntaxError ? error_.message : "parse error"}`;
+          errorEl.hidden = false;
+        }
+      });
+      textarea.addEventListener("input", () => {
+        textarea.classList.remove("settings-field-error");
+        errorEl.hidden = true;
+      });
+      const group = document.createElement("div");
+      group.append(textarea, errorEl);
+      return group;
+    }
+
     return textarea;
   }
   const input = createTextInput({
@@ -151,6 +197,38 @@ function buildControl(field: SettingsFieldDefinition, options: SettingsFieldRend
   input.addEventListener("input", () => options.onInput(input.value));
   input.addEventListener("focus", options.onFocus);
 
+  if (field.kind === "number") {
+    const errorEl = createInlineError();
+    input.addEventListener("blur", () => {
+      const val = input.value.trim();
+      if (val !== "" && !Number.isFinite(Number(val))) {
+        input.classList.add("settings-field-error");
+        errorEl.textContent = "Must be a valid number.";
+        errorEl.hidden = false;
+      } else {
+        input.classList.remove("settings-field-error");
+        errorEl.hidden = true;
+      }
+    });
+    input.addEventListener("input", () => {
+      input.classList.remove("settings-field-error");
+      errorEl.hidden = true;
+    });
+
+    if (field.actionLabel && options.onAction) {
+      const row = document.createElement("div");
+      row.className = "settings-field-action-row";
+      const btn = createButton(field.actionLabel, "ghost");
+      btn.addEventListener("click", options.onAction);
+      row.append(input, btn, errorEl);
+      return row;
+    }
+
+    const group = document.createElement("div");
+    group.append(input, errorEl);
+    return group;
+  }
+
   if (field.actionLabel && options.onAction) {
     const row = document.createElement("div");
     row.className = "settings-field-action-row";
@@ -161,4 +239,11 @@ function buildControl(field: SettingsFieldDefinition, options: SettingsFieldRend
   }
 
   return input;
+}
+
+function createInlineError(): HTMLParagraphElement {
+  const errorEl = document.createElement("p");
+  errorEl.className = "settings-field-error-text";
+  errorEl.hidden = true;
+  return errorEl;
 }

--- a/frontend/src/views/settings-sections.ts
+++ b/frontend/src/views/settings-sections.ts
@@ -5,6 +5,7 @@ import {
   buildSectionDiffPreview,
   buildUnderlyingPaths,
   ensureSectionDrafts,
+  formatFieldDraft,
   SECTION_GROUPS,
   sectionGroups,
   sectionMatchesFilter,
@@ -12,6 +13,7 @@ import {
   type SettingsSectionDefinition,
 } from "./settings-helpers";
 import { createSectionAction, createSettingsField } from "./settings-forms";
+import { getValueAtPath } from "./settings-paths";
 import type { SettingsState } from "./settings-state";
 
 interface SettingsRenderOptions {
@@ -110,6 +112,32 @@ function createNavItem(
     badge.className = "settings-start-here";
     badge.textContent = "Start here";
     topRow.append(badge);
+  }
+
+  const hasOverrides = section.prefixes.some((prefix) => getValueAtPath(state.overlay, prefix) !== undefined);
+  if (hasOverrides) {
+    const modifiedBadge = document.createElement("span");
+    modifiedBadge.className = "settings-nav-badge-modified";
+    modifiedBadge.setAttribute("aria-label", "Has saved overrides");
+    topRow.append(modifiedBadge);
+  }
+
+  const sectionDrafts = state.drafts[section.id];
+  if (sectionDrafts) {
+    const hasUnsaved = Object.entries(sectionDrafts).some(([path, draftValue]) => {
+      const effectiveValue = getValueAtPath(state.effective, path);
+      const formatted = formatFieldDraft(
+        section.fields.find((field) => field.path === path) ?? { path, label: "", kind: "text" },
+        effectiveValue,
+      );
+      return draftValue !== formatted;
+    });
+    if (hasUnsaved) {
+      const unsavedBadge = document.createElement("span");
+      unsavedBadge.className = "settings-nav-badge-unsaved";
+      unsavedBadge.setAttribute("aria-label", "Has unsaved changes");
+      topRow.append(unsavedBadge);
+    }
   }
 
   const desc = document.createElement("span");
@@ -360,11 +388,13 @@ function createGroupGrid(
   const grid = document.createElement("div");
   grid.className = "form-grid settings-grid";
 
-  group.fields.forEach((field) => {
+  group.fields.forEach((field, fieldIndex) => {
     const actionKind = field.actionKind;
+    const hintId = `settings-hint-${section.id}-${fieldIndex}`;
     grid.append(
       createSettingsField(field, {
         value: drafts[field.path] ?? "",
+        hintId,
         onInput: (value) => {
           drafts[field.path] = value;
           state.error = null;


### PR DESCRIPTION
## Summary
- **Modified badge** (teal dot) on nav items when a section has saved overlay overrides
- **Unsaved badge** (amber dot) when drafts differ from effective values
- **Inline blur validation** for `number` fields (must be finite) and `json` fields (must parse), advisory only — does not block save
- **Deterministic `hintId`** wired through `aria-describedby` on all settings field controls

## Files changed
- `frontend/src/views/settings-sections.ts` — badge logic in `createNavItem()`, `hintId` plumbing in `createGroupGrid()`
- `frontend/src/views/settings-forms.ts` — `hintId` option, `aria-describedby` wiring, number/JSON blur validation, `createInlineError` helper
- `frontend/src/styles/settings.css` — badge dot styles, inline validation error styles

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm run format:check` passes
- [x] `npm test` — 1560 tests pass
- [x] `npx playwright test --project=smoke` — 87 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
