### PR TITLE
feat(settings): remove tab shell for unified scrollable view

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -125,7 +125,7 @@ router.register("/issues/:id/logs", logs);
 router.register("/logs/:id", logs);
 router.register("/attempts/:id", attempt);
 
-router.register("/config", aliasSettingsRoute("/settings#advanced", settings));
+router.register("/config", aliasSettingsRoute("/settings#devtools", settings));
 router.register("/secrets", aliasSettingsRoute("/settings#credentials", settings));
 router.register("/observability", observability);
 router.register("/settings", settings);

--- a/frontend/src/styles/unified-settings.css
+++ b/frontend/src/styles/unified-settings.css
@@ -1,48 +1,41 @@
-.settings-shell-page {
+.settings-unified-page {
   gap: var(--space-5);
 }
 
-.settings-shell-tabs {
-  padding: var(--space-2);
+.settings-unified-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
 }
 
-.settings-shell-tablist {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  width: 100%;
+.settings-credentials-section {
+  padding: var(--space-5);
 }
 
-.settings-shell-tab {
-  min-width: 0;
-  width: 100%;
-  justify-content: center;
+.settings-section-header {
+  margin-bottom: var(--space-4);
 }
 
-.settings-shell-tab.is-active {
-  background: var(--bg-elevated);
-  border-color: var(--border-strong);
-  color: var(--text-primary);
-}
-
-.settings-shell-context {
+.settings-section-header-row {
+  display: flex;
   align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
 }
 
-.settings-shell-context-copy {
+.settings-section-header-row > div:first-child {
   display: grid;
   gap: var(--space-1);
 }
 
-.settings-shell-context-eyebrow {
-  margin: 0;
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  letter-spacing: var(--tracking-wider);
-  text-transform: uppercase;
-  color: var(--text-muted);
+.settings-section-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
 }
 
-.settings-shell-context-title {
+.settings-section-header h2 {
   margin: 0;
   font-family: var(--font-heading);
   font-size: var(--text-xl);
@@ -50,62 +43,80 @@
   color: var(--text-primary);
 }
 
-.settings-shell-context-subtitle {
+.settings-section-header p {
   margin: 0;
   max-width: 72ch;
   color: var(--text-secondary);
 }
 
-.settings-shell-context-actions {
+.settings-devtools-section {
+  padding: var(--space-5);
+}
+
+.settings-devtools-section summary {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  flex-wrap: wrap;
+  cursor: pointer;
+  font-family: var(--font-heading);
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--text-secondary);
+  list-style: none;
+  user-select: none;
 }
 
-.settings-shell-panels,
-.settings-shell-panel {
-  min-width: 0;
+.settings-devtools-section summary::-webkit-details-marker {
+  display: none;
 }
 
-.settings-shell-mounted-view {
+.settings-devtools-section summary::before {
+  content: "\25B6";
+  font-size: var(--text-xs);
+  transition: transform 0.15s ease;
+  color: var(--text-muted);
+}
+
+.settings-devtools-section[open] summary::before {
+  transform: rotate(90deg);
+}
+
+.settings-devtools-section[open] summary {
+  color: var(--text-primary);
+  margin-bottom: var(--space-4);
+}
+
+.settings-devtools-section summary:focus-visible {
+  outline: 2px solid var(--interactive-primary);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.settings-devtools-content {
   gap: var(--space-5);
 }
 
-.settings-shell-mounted-view .config-help-banner {
+.settings-devtools-content .config-help-banner {
   margin: 0;
 }
 
-.settings-shell-mounted-view .config-content {
+.settings-devtools-content .config-content {
   padding: 0;
 }
 
 @media (max-width: 980px) {
-  .settings-shell-tab {
-    min-width: 0;
-  }
-
-  .settings-shell-context {
-    flex-direction: column;
-  }
-
-  .settings-shell-context-actions {
-    width: 100%;
-    justify-content: flex-start;
+  .settings-credentials-section,
+  .settings-devtools-section {
+    padding: var(--space-4);
   }
 }
 
 @media (max-width: 760px) {
-  .settings-shell-page {
+  .settings-unified-page {
     gap: var(--space-4);
   }
 
-  .settings-shell-tablist {
-    grid-template-columns: 1fr;
-  }
-
-  .settings-shell-tab {
-    min-width: 0;
-    width: 100%;
+  .settings-unified-body {
+    gap: var(--space-4);
   }
 }

--- a/frontend/src/ui/command-palette-data.ts
+++ b/frontend/src/ui/command-palette-data.ts
@@ -47,14 +47,14 @@ function buildNavigationEntries(): PaletteEntry[] {
       run: () => router.navigate("/settings#credentials"),
     },
     {
-      id: "nav:/settings#advanced",
-      name: "Advanced settings",
-      description: "Open Settings · Advanced",
+      id: "nav:/settings#devtools",
+      name: "Developer tools",
+      description: "Open Settings · Developer tools",
       meta: "g c",
       group: "Navigation",
       icon: "config",
-      keywords: ["configure", "config", "advanced", "override", "/config", "/settings#advanced"],
-      run: () => router.navigate("/settings#advanced"),
+      keywords: ["configure", "config", "devtools", "developer", "override", "/config", "/settings#devtools"],
+      run: () => router.navigate("/settings#devtools"),
     },
   );
 

--- a/frontend/src/ui/keyboard.ts
+++ b/frontend/src/ui/keyboard.ts
@@ -30,7 +30,7 @@ function handlePrefixKey(event: KeyboardEvent, router: Router, options: Keyboard
   const destinations: Record<string, string> = {
     o: "/",
     q: "/queue",
-    c: "/settings#advanced",
+    c: "/settings#devtools",
     s: "/settings#credentials",
     m: "/observability",
     n: "/notifications",

--- a/frontend/src/utils/settings-tabs.ts
+++ b/frontend/src/utils/settings-tabs.ts
@@ -1,25 +1,25 @@
-export type SettingsTabId = "general" | "credentials" | "advanced";
+export type SettingsSectionHash = "credentials" | "devtools";
 
-export const DEFAULT_SETTINGS_TAB: SettingsTabId = "general";
+const DEFAULT_SETTINGS_PATH = "/settings";
 
-const settingsTabs = new Set<SettingsTabId>(["general", "credentials", "advanced"]);
+const sectionHashes = new Set<SettingsSectionHash>(["credentials", "devtools"]);
 
-export function isSettingsTabId(value: string | null | undefined): value is SettingsTabId {
-  return value !== undefined && value !== null && settingsTabs.has(value as SettingsTabId);
+function isSettingsSectionHash(value: string | null | undefined): value is SettingsSectionHash {
+  return value !== undefined && value !== null && sectionHashes.has(value as SettingsSectionHash);
 }
 
-export function parseSettingsTabHash(hash: string): SettingsTabId {
+export function parseSettingsSectionHash(hash: string): SettingsSectionHash | null {
   const normalized = hash.replace(/^#/, "").trim().toLowerCase();
-  return isSettingsTabId(normalized) ? normalized : DEFAULT_SETTINGS_TAB;
+  return isSettingsSectionHash(normalized) ? normalized : null;
 }
 
-export function settingsPathForTab(tab: SettingsTabId): string {
-  return tab === DEFAULT_SETTINGS_TAB ? "/settings#general" : `/settings#${tab}`;
+export function settingsPathForSection(section: SettingsSectionHash | null): string {
+  return section ? `/settings#${section}` : DEFAULT_SETTINGS_PATH;
 }
 
-export function normalizeLegacySettingsPath(pathname: string): SettingsTabId | null {
+export function normalizeLegacySettingsPath(pathname: string): SettingsSectionHash | null {
   if (pathname === "/config") {
-    return "advanced";
+    return "devtools";
   }
   if (pathname === "/secrets") {
     return "credentials";

--- a/frontend/src/views/config-view.ts
+++ b/frontend/src/views/config-view.ts
@@ -28,26 +28,46 @@ export function createConfigPage(options: ConfigPageOptions = {}): HTMLElement {
   // Help banner that can be dismissed
   const helpBanner = document.createElement("section");
   helpBanner.className = "config-help-banner";
-  helpBanner.innerHTML = `
-    <div class="config-help-content">
-      <div class="config-help-icon">💡</div>
-      <div class="config-help-text">
-        <strong>New to config overrides?</strong>
-        Use dotted paths like <code>tracker.project_slug</code> to override specific settings.
-        <a href="#" class="config-help-link" data-action="show-schema">Browse available paths →</a>
-      </div>
-    </div>
-    <button class="config-help-dismiss" aria-label="Dismiss help">×</button>
-  `;
+
+  const helpContent = document.createElement("div");
+  helpContent.className = "config-help-content";
+
+  const helpIcon = document.createElement("div");
+  helpIcon.className = "config-help-icon";
+  helpIcon.textContent = "\uD83D\uDCA1";
+
+  const helpText = document.createElement("div");
+  helpText.className = "config-help-text";
+  const helpStrong = document.createElement("strong");
+  helpStrong.textContent = "New to config overrides?";
+  const helpDescription = document.createTextNode(" Use dotted paths like ");
+  const helpCode = document.createElement("code");
+  helpCode.textContent = "tracker.project_slug";
+  const helpSuffix = document.createTextNode(" to override specific settings. ");
+  const helpLink = document.createElement("a");
+  helpLink.href = "#";
+  helpLink.className = "config-help-link";
+  helpLink.dataset.action = "show-schema";
+  helpLink.textContent = "Browse available paths \u2192";
+  helpText.append(helpStrong, helpDescription, helpCode, helpSuffix, helpLink);
+
+  helpContent.append(helpIcon, helpText);
+
+  const helpDismiss = document.createElement("button");
+  helpDismiss.className = "config-help-dismiss";
+  helpDismiss.setAttribute("aria-label", "Dismiss help");
+  helpDismiss.textContent = "\u00D7";
+
+  helpBanner.append(helpContent, helpDismiss);
 
   // Dismiss help banner
-  helpBanner.querySelector(".config-help-dismiss")?.addEventListener("click", () => {
+  helpDismiss.addEventListener("click", () => {
     helpBanner.classList.add("is-hidden");
     localStorage.setItem("symphony.configHelpDismissed", "true");
   });
 
   // Show schema link
-  helpBanner.querySelector("[data-action='show-schema']")?.addEventListener("click", (e) => {
+  helpLink.addEventListener("click", (e) => {
     e.preventDefault();
     state.showSchema = true;
     render();

--- a/frontend/src/views/git-view.ts
+++ b/frontend/src/views/git-view.ts
@@ -270,7 +270,7 @@ function buildQuickLinksRail(githubAvailable: boolean): HTMLElement[] {
   links.append(queueBtn);
   const configBtn = el("button", "git-quick-link-btn", "Advanced settings");
   configBtn.type = "button";
-  configBtn.addEventListener("click", () => router.navigate("/settings#advanced"));
+  configBtn.addEventListener("click", () => router.navigate("/settings#devtools"));
   links.append(configBtn);
   const credentialsBtn = el("button", "git-quick-link-btn", "Manage credentials");
   credentialsBtn.type = "button";
@@ -320,7 +320,7 @@ function renderGitContext(page: HTMLElement, data: GitContextResponse): void {
         "No repositories configured",
         "Add repos to your workflow YAML to see git context here. Each repo entry maps a Linear identifier prefix to a GitHub repository.",
         "Open advanced settings",
-        () => router.navigate("/settings#advanced"),
+        () => router.navigate("/settings#devtools"),
       ),
     );
     return;

--- a/frontend/src/views/unified-settings-view.ts
+++ b/frontend/src/views/unified-settings-view.ts
@@ -1,11 +1,10 @@
 import { createPageHeader } from "../components/page-header.js";
 import { registerPageCleanup } from "../utils/page.js";
 import {
-  DEFAULT_SETTINGS_TAB,
   normalizeLegacySettingsPath,
-  parseSettingsTabHash,
-  settingsPathForTab,
-  type SettingsTabId,
+  parseSettingsSectionHash,
+  settingsPathForSection,
+  type SettingsSectionHash,
 } from "../utils/settings-tabs.js";
 
 import { createConfigState } from "./config-state.js";
@@ -15,81 +14,24 @@ import { createSecretsPage } from "./secrets-view.js";
 import { createSettingsState } from "./settings-state.js";
 import { createSettingsPage } from "./settings-view.js";
 
-interface SettingsTabDefinition {
-  actionLabel: string;
-  description: string;
-  id: SettingsTabId;
-  label: string;
-  title: string;
-}
-
 interface UnifiedSettingsCache {
-  activeTab: SettingsTabId;
   advancedState: ReturnType<typeof createConfigState>;
   credentialsState: ReturnType<typeof createSecretsState>;
   generalState: ReturnType<typeof createSettingsState>;
 }
 
-const TAB_DEFINITIONS: SettingsTabDefinition[] = [
-  {
-    id: "general",
-    label: "General",
-    title: "General",
-    actionLabel: "General settings",
-    description:
-      "Review the structured, schema-guided configuration Symphony uses for tracker, provider, and runtime behavior.",
-  },
-  {
-    id: "credentials",
-    label: "Credentials",
-    title: "Credentials",
-    actionLabel: "Credentials",
-    description: "Manage encrypted API keys and tokens. Values remain write-only after save.",
-  },
-  {
-    id: "advanced",
-    label: "Advanced",
-    title: "Advanced",
-    actionLabel: "Advanced",
-    description: "Inspect and edit persistent overlay overrides directly when you need path-level or raw JSON control.",
-  },
-];
-
 let cachedState: UnifiedSettingsCache | null = null;
-
-function getTabDefinition(tab: SettingsTabId): SettingsTabDefinition {
-  return TAB_DEFINITIONS.find((candidate) => candidate.id === tab) ?? TAB_DEFINITIONS[0]!;
-}
 
 function getCachedState(): UnifiedSettingsCache {
   if (cachedState) {
     return cachedState;
   }
   cachedState = {
-    activeTab: DEFAULT_SETTINGS_TAB,
     generalState: createSettingsState(),
     credentialsState: createSecretsState(),
     advancedState: createConfigState(),
   };
   return cachedState;
-}
-
-function readRequestedTab(): { tab: SettingsTabId; shouldReplace: boolean } {
-  const legacyTab = normalizeLegacySettingsPath(window.location.pathname);
-  if (legacyTab) {
-    return { tab: legacyTab, shouldReplace: true };
-  }
-  return { tab: parseSettingsTabHash(window.location.hash), shouldReplace: false };
-}
-
-function createSubpage(tab: SettingsTabId, state: UnifiedSettingsCache): HTMLElement {
-  if (tab === "credentials") {
-    return createSecretsPage({ state: state.credentialsState });
-  }
-  if (tab === "advanced") {
-    return createConfigPage({ state: state.advancedState });
-  }
-  return createSettingsPage({ state: state.generalState });
 }
 
 function extractHeader(root: HTMLElement): { actions: HTMLElement[]; subtitle: string } {
@@ -109,180 +51,119 @@ function extractHeader(root: HTMLElement): { actions: HTMLElement[]; subtitle: s
   return { actions, subtitle };
 }
 
+function readRequestedSection(): { section: SettingsSectionHash | null; shouldReplace: boolean } {
+  const legacySection = normalizeLegacySettingsPath(window.location.pathname);
+  if (legacySection) {
+    return { section: legacySection, shouldReplace: true };
+  }
+  return { section: parseSettingsSectionHash(window.location.hash), shouldReplace: false };
+}
+
+function scrollToSection(section: SettingsSectionHash, container: HTMLElement): void {
+  if (section === "credentials") {
+    const credentialsEl = container.querySelector<HTMLElement>(".settings-credentials-section");
+    credentialsEl?.scrollIntoView({ behavior: "smooth", block: "start" });
+  } else if (section === "devtools") {
+    const devtoolsEl = container.querySelector<HTMLDetailsElement>(".settings-devtools-section");
+    if (devtoolsEl) {
+      devtoolsEl.open = true;
+      devtoolsEl.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }
+}
+
+function buildCredentialsSection(state: UnifiedSettingsCache): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "settings-credentials-section mc-panel";
+
+  const secretsPage = createSecretsPage({ state: state.credentialsState });
+  const extracted = extractHeader(secretsPage);
+
+  const sectionHeader = document.createElement("div");
+  sectionHeader.className = "settings-section-header";
+  const headerRow = document.createElement("div");
+  headerRow.className = "settings-section-header-row";
+  const headerCopy = document.createElement("div");
+  const heading = document.createElement("h2");
+  heading.textContent = "Credentials";
+  const description = document.createElement("p");
+  description.textContent = "Manage encrypted API keys and tokens. Values remain write-only after save.";
+  headerCopy.append(heading, description);
+  headerRow.append(headerCopy);
+  if (extracted.actions.length > 0) {
+    const actionsWrap = document.createElement("div");
+    actionsWrap.className = "settings-section-header-actions";
+    actionsWrap.append(...extracted.actions);
+    headerRow.append(actionsWrap);
+  }
+  sectionHeader.append(headerRow);
+
+  section.append(sectionHeader, secretsPage);
+  return section;
+}
+
+function buildDevtoolsSection(state: UnifiedSettingsCache): HTMLDetailsElement {
+  const details = document.createElement("details");
+  details.className = "settings-devtools-section mc-panel";
+
+  const summary = document.createElement("summary");
+  summary.textContent = "Developer tools \u2014 Raw JSON configuration editor";
+  details.append(summary);
+
+  const configPage = createConfigPage({ state: state.advancedState });
+  extractHeader(configPage);
+  configPage.classList.add("settings-devtools-content");
+
+  details.append(configPage);
+  return details;
+}
+
 export function createUnifiedSettingsPage(): HTMLElement {
   const state = getCachedState();
-  const requested = readRequestedTab();
-  state.activeTab = requested.tab;
+  const requested = readRequestedSection();
 
-  if (requested.shouldReplace) {
-    window.history.replaceState({}, "", settingsPathForTab(requested.tab));
+  if (requested.shouldReplace && requested.section) {
+    window.history.replaceState({}, "", settingsPathForSection(requested.section));
   }
 
   const page = document.createElement("div");
-  page.className = "page settings-shell-page fade-in";
+  page.className = "page settings-unified-page fade-in";
 
-  const header = createPageHeader(
-    "Settings",
-    "One place to manage guided configuration, encrypted credentials, and low-level overrides.",
-  );
+  const header = createPageHeader("Settings", "Manage configuration, credentials, and developer tools in one place.");
 
-  const tabsSurface = document.createElement("section");
-  tabsSurface.className = "settings-shell-tabs mc-panel";
-  const tabList = document.createElement("div");
-  tabList.className = "mc-button-segment settings-shell-tablist";
-  tabList.setAttribute("role", "tablist");
-  tabList.setAttribute("aria-label", "Settings sections");
-  tabList.setAttribute("aria-orientation", "horizontal");
-  tabsSurface.append(tabList);
+  const body = document.createElement("div");
+  body.className = "settings-unified-body";
 
-  const context = document.createElement("section");
-  context.className = "settings-shell-context mc-strip";
-  const contextCopy = document.createElement("div");
-  contextCopy.className = "settings-shell-context-copy";
-  const contextEyebrow = document.createElement("p");
-  contextEyebrow.className = "settings-shell-context-eyebrow";
-  const contextTitle = document.createElement("h2");
-  contextTitle.className = "settings-shell-context-title";
-  const contextSubtitle = document.createElement("p");
-  contextSubtitle.className = "settings-shell-context-subtitle";
-  contextCopy.append(contextEyebrow, contextTitle, contextSubtitle);
-  const contextActions = document.createElement("div");
-  contextActions.className = "settings-shell-context-actions";
-  context.append(contextCopy, contextActions);
+  const generalSection = createSettingsPage({ state: state.generalState });
+  const credentialsSection = buildCredentialsSection(state);
+  const devtoolsSection = buildDevtoolsSection(state);
 
-  const content = document.createElement("div");
-  content.className = "settings-shell-panels";
+  body.append(generalSection, credentialsSection, devtoolsSection);
+  page.append(header, body);
 
-  const panels = new Map<SettingsTabId, HTMLElement>();
-  const buttons = new Map<SettingsTabId, HTMLButtonElement>();
-
-  function renderTabButtons(): void {
-    tabList.replaceChildren(
-      ...TAB_DEFINITIONS.map((tab) => {
-        const button = document.createElement("button");
-        button.type = "button";
-        button.className = `mc-button is-ghost settings-shell-tab${tab.id === state.activeTab ? " is-active" : ""}`;
-        button.id = `settings-tab-${tab.id}`;
-        button.dataset.tab = tab.id;
-        button.setAttribute("role", "tab");
-        button.setAttribute("aria-selected", String(tab.id === state.activeTab));
-        button.setAttribute("aria-controls", `settings-panel-${tab.id}`);
-        button.setAttribute("tabindex", tab.id === state.activeTab ? "0" : "-1");
-        button.textContent = tab.label;
-        button.addEventListener("click", () => activateTab(tab.id, "push"));
-        button.addEventListener("keydown", (event) => {
-          const currentIndex = TAB_DEFINITIONS.findIndex((candidate) => candidate.id === tab.id);
-          const previousIndex = currentIndex === 0 ? TAB_DEFINITIONS.length - 1 : currentIndex - 1;
-          const nextIndex = currentIndex === TAB_DEFINITIONS.length - 1 ? 0 : currentIndex + 1;
-          if (event.key === "ArrowLeft") {
-            event.preventDefault();
-            buttons.get(TAB_DEFINITIONS[previousIndex]!.id)?.focus();
-          }
-          if (event.key === "ArrowRight") {
-            event.preventDefault();
-            buttons.get(TAB_DEFINITIONS[nextIndex]!.id)?.focus();
-          }
-          if (event.key === "Home") {
-            event.preventDefault();
-            buttons.get(TAB_DEFINITIONS[0]!.id)?.focus();
-          }
-          if (event.key === "End") {
-            event.preventDefault();
-            buttons.get(TAB_DEFINITIONS.at(-1)!.id)?.focus();
-          }
-          if (event.key === " " || event.key === "Enter") {
-            event.preventDefault();
-            activateTab(tab.id, "push");
-          }
-        });
-        buttons.set(tab.id, button);
-        return button;
-      }),
-    );
-  }
-
-  function renderPanels(): void {
-    for (const tab of TAB_DEFINITIONS) {
-      let panel = panels.get(tab.id);
-      if (!panel) {
-        panel = document.createElement("section");
-        panel.className = "settings-shell-panel";
-        panel.id = `settings-panel-${tab.id}`;
-        panel.dataset.tab = tab.id;
-        panel.setAttribute("role", "tabpanel");
-        panel.setAttribute("aria-labelledby", `settings-tab-${tab.id}`);
-        panels.set(tab.id, panel);
-      }
-
-      const isActive = tab.id === state.activeTab;
-      panel.hidden = !isActive;
-
-      if (!isActive) {
-        panel.replaceChildren();
-        continue;
-      }
-
-      const subpage = createSubpage(tab.id, state);
-      const extracted = extractHeader(subpage);
-      const definition = getTabDefinition(tab.id);
-
-      contextEyebrow.textContent = definition.actionLabel;
-      contextTitle.textContent = definition.title;
-      contextSubtitle.textContent = extracted.subtitle || definition.description;
-      contextActions.replaceChildren(...extracted.actions);
-      subpage.classList.add("settings-shell-mounted-view");
-      panel.replaceChildren(subpage);
-    }
-
-    content.replaceChildren(...TAB_DEFINITIONS.map((tab) => panels.get(tab.id)!));
-  }
-
-  function syncUrl(tab: SettingsTabId, mode: "push" | "replace" | "none"): void {
-    if (mode === "none") {
-      return;
-    }
-    const nextUrl = settingsPathForTab(tab);
-    const currentUrl = `${window.location.pathname}${window.location.hash}`;
-    if (currentUrl === nextUrl) {
-      return;
-    }
-    if (mode === "replace") {
-      window.history.replaceState({}, "", nextUrl);
-      return;
-    }
-    window.history.pushState({}, "", nextUrl);
-  }
-
-  function render(): void {
-    renderTabButtons();
-    renderPanels();
-  }
-
-  function activateTab(tab: SettingsTabId, mode: "push" | "replace" | "none"): void {
-    if (tab === state.activeTab && mode !== "replace") {
-      syncUrl(tab, mode);
-      return;
-    }
-    state.activeTab = tab;
-    syncUrl(tab, mode);
-    render();
+  // Scroll to requested section after initial render
+  if (requested.section) {
+    const targetSection = requested.section;
+    requestAnimationFrame(() => {
+      scrollToSection(targetSection, page);
+    });
   }
 
   const onHashChange = (): void => {
-    const requestedTab = readRequestedTab();
-    if (requestedTab.shouldReplace) {
-      activateTab(requestedTab.tab, "replace");
-      return;
+    const next = readRequestedSection();
+    if (next.shouldReplace && next.section) {
+      window.history.replaceState({}, "", settingsPathForSection(next.section));
     }
-    activateTab(requestedTab.tab, "none");
+    if (next.section) {
+      scrollToSection(next.section, page);
+    }
   };
 
   window.addEventListener("hashchange", onHashChange);
-  page.append(header, tabsSurface, context, content);
-  render();
 
   registerPageCleanup(page, () => {
     window.removeEventListener("hashchange", onHashChange);
+    cachedState = null;
   });
 
   return page;

--- a/frontend/src/views/welcome-view.ts
+++ b/frontend/src/views/welcome-view.ts
@@ -91,7 +91,7 @@ export function createWelcomePage(): HTMLElement {
       linkEl.addEventListener("click", (e) => {
         e.preventDefault();
         const paths: Record<string, string> = {
-          "View example": "/settings#advanced",
+          "View example": "/settings#devtools",
           "Open Credentials": "/settings#credentials",
           "Open Settings": "/settings",
         };

--- a/tests/e2e/pages/config.page.ts
+++ b/tests/e2e/pages/config.page.ts
@@ -15,21 +15,28 @@ export class ConfigPage extends BasePage {
   }
 
   async navigateToConfig(): Promise<void> {
-    await this.goto("/config");
+    await this.goto("/settings#devtools");
     await this.waitForPageContent();
+    await this.devToolsSection.waitFor({ state: "attached" });
+    // Wait for the details element to open (triggered by hash navigation)
+    await this.page.waitForFunction(() => {
+      const details = document.querySelector<HTMLDetailsElement>(".settings-devtools-section");
+      return details?.open === true;
+    });
   }
 
   async navigateToSecrets(): Promise<void> {
-    await this.goto("/secrets");
+    await this.goto("/settings#credentials");
     await this.waitForPageContent();
+    await this.credentialsSection.waitFor({ state: "attached" });
   }
 
-  tabButton(name: "General" | "Credentials" | "Advanced"): Locator {
-    return this.page.getByRole("tab", { name });
+  get credentialsSection(): Locator {
+    return this.page.locator(".settings-credentials-section");
   }
 
-  get activeTab(): Locator {
-    return this.page.locator('[role="tab"][aria-selected="true"]');
+  get devToolsSection(): Locator {
+    return this.page.locator(".settings-devtools-section");
   }
 
   // ── Config View ──────────────────────────────────────────────────────

--- a/tests/e2e/specs/smoke/config-secrets.smoke.spec.ts
+++ b/tests/e2e/specs/smoke/config-secrets.smoke.spec.ts
@@ -7,12 +7,13 @@ test.describe("Unified Settings Smoke", () => {
     await apiMock.install(scenario);
   });
 
-  test("settings page loads the General tab by default", async ({ page }) => {
+  test("settings page loads with general settings visible by default", async ({ page }) => {
     const settings = new ConfigPage(page);
     await settings.navigateToSettings();
 
-    await expect(settings.tabButton("General")).toHaveAttribute("aria-selected", "true");
     await expect(page.locator("h1, .page-title").first()).toContainText("Settings");
+    // General settings rail should be visible
+    await expect(page.locator(".settings-rail")).toBeVisible({ timeout: 5000 });
   });
 
   test("configure nav is consolidated to a single Settings entry", async ({ page }) => {
@@ -24,72 +25,61 @@ test.describe("Unified Settings Smoke", () => {
     await expect(page.locator('.sidebar-item[data-path="/secrets"]')).toHaveCount(0);
   });
 
-  // ── Advanced Tab / Legacy Config Alias ─────────────────────────────
+  // ── Dev Tools / Legacy Config Alias ──────────────────────────────
 
-  test("legacy /config route redirects to Settings → Advanced", async ({ page }) => {
+  test("legacy /config route redirects to Settings with devtools hash", async ({ page }) => {
     const config = new ConfigPage(page);
     await config.navigateToConfig();
 
     expect(new URL(page.url()).pathname).toBe("/settings");
-    expect(new URL(page.url()).hash).toBe("#advanced");
-    await expect(config.tabButton("Advanced")).toHaveAttribute("aria-selected", "true");
+    expect(new URL(page.url()).hash).toBe("#devtools");
+    await expect(config.devToolsSection).toBeAttached();
   });
 
-  test("advanced tab shows overlay entries", async ({ page }) => {
+  test("devtools section shows overlay entries when opened", async ({ page }) => {
     const config = new ConfigPage(page);
     await config.navigateToConfig();
 
+    // Details is opened automatically by hash navigation
+    await expect(config.devToolsSection).toHaveAttribute("open", "");
     await expect(page.getByText("codex.model").first()).toBeVisible({ timeout: 5000 });
     await expect(page.getByText("orchestrator.max_concurrent").first()).toBeVisible({ timeout: 5000 });
   });
 
-  test("advanced tab shows config editor mode buttons", async ({ page }) => {
+  test("devtools section shows config editor mode buttons when opened", async ({ page }) => {
     const config = new ConfigPage(page);
     await config.navigateToConfig();
 
+    await expect(config.devToolsSection).toHaveAttribute("open", "");
     await expect(page.locator(".config-mode-label").first()).toBeVisible({ timeout: 5000 });
   });
 
-  test("advanced tab preserves unsaved raw edits across tab switches", async ({ page }) => {
-    const config = new ConfigPage(page);
-    await config.navigateToConfig();
+  // ── Credentials / Legacy Secrets Alias ───────────────────────────
 
-    await page.getByRole("button", { name: "Raw JSON" }).click();
-    const editor = page.locator(".config-textarea-large");
-    await editor.fill('{"draft":"keep-me"}');
-
-    await config.tabButton("Credentials").click();
-    await config.tabButton("Advanced").click();
-
-    await expect(editor).toHaveValue('{"draft":"keep-me"}');
-  });
-
-  // ── Credentials Tab / Legacy Secrets Alias ────────────────────────
-
-  test("legacy /secrets route redirects to Settings → Credentials", async ({ page }) => {
+  test("legacy /secrets route redirects to Settings with credentials hash", async ({ page }) => {
     const config = new ConfigPage(page);
     await config.navigateToSecrets();
 
     expect(new URL(page.url()).pathname).toBe("/settings");
     expect(new URL(page.url()).hash).toBe("#credentials");
-    await expect(config.tabButton("Credentials")).toHaveAttribute("aria-selected", "true");
+    await expect(config.credentialsSection).toBeAttached();
   });
 
-  test("credentials tab shows secret information", async ({ page }) => {
+  test("credentials section shows secret information", async ({ page }) => {
     const config = new ConfigPage(page);
     await config.navigateToSecrets();
 
     await expect(page.getByText(/LINEAR_API_KEY/).first()).toBeVisible({ timeout: 5000 });
   });
 
-  test("credentials tab has new secret button", async ({ page }) => {
+  test("credentials section has new secret button", async ({ page }) => {
     const config = new ConfigPage(page);
     await config.navigateToSecrets();
 
     await expect(page.getByText("New secret")).toBeVisible({ timeout: 5000 });
   });
 
-  test("global keyboard aliases open Advanced and Credentials tabs", async ({ page }) => {
+  test("global keyboard aliases open devtools and credentials sections", async ({ page }) => {
     await page.goto("/");
     await page.waitForSelector("#main-content", { state: "attached" });
     await page.waitForFunction(() => {
@@ -99,13 +89,11 @@ test.describe("Unified Settings Smoke", () => {
 
     await page.keyboard.press("g");
     await page.keyboard.press("c");
-    await expect(page.getByRole("tab", { name: "Advanced" })).toHaveAttribute("aria-selected", "true");
     expect(new URL(page.url()).pathname).toBe("/settings");
-    expect(new URL(page.url()).hash).toBe("#advanced");
+    expect(new URL(page.url()).hash).toBe("#devtools");
 
     await page.keyboard.press("g");
     await page.keyboard.press("s");
-    await expect(page.getByRole("tab", { name: "Credentials" })).toHaveAttribute("aria-selected", "true");
     expect(new URL(page.url()).hash).toBe("#credentials");
   });
 });

--- a/tests/e2e/specs/smoke/settings-interactions.smoke.spec.ts
+++ b/tests/e2e/specs/smoke/settings-interactions.smoke.spec.ts
@@ -7,7 +7,7 @@ test.describe("Settings Interaction Smoke", () => {
     await apiMock.install(scenario);
   });
 
-  // ── Advanced Tab: Raw JSON Config Editing ────────────────────────────
+  // ── Dev Tools: Raw JSON Config Editing ──────────────────────────────
 
   test("raw JSON mode: editing and saving sends PUT with correct payload", async ({ page }) => {
     const settings = new ConfigPage(page);
@@ -72,7 +72,7 @@ test.describe("Settings Interaction Smoke", () => {
     expect(putSent).toBe(false);
   });
 
-  // ── Credentials Tab: Create Secret ───────────────────────────────────
+  // ── Credentials: Create Secret ─────────────────────────────────────
 
   test("new secret: filling form and submitting sends POST with value", async ({ page }) => {
     const settings = new ConfigPage(page);
@@ -95,7 +95,7 @@ test.describe("Settings Interaction Smoke", () => {
     expect(body).toHaveProperty("value", "super-secret-value-123");
   });
 
-  // ── Credentials Tab: Delete Secret ───────────────────────────────────
+  // ── Credentials: Delete Secret ─────────────────────────────────────
 
   test("delete secret: confirming deletion sends DELETE request", async ({ page }) => {
     const settings = new ConfigPage(page);
@@ -122,7 +122,7 @@ test.describe("Settings Interaction Smoke", () => {
     expect(deleteRequest.url()).toContain("/api/v1/secrets/LINEAR_API_KEY");
   });
 
-  // ── Credentials Tab: Empty Key/Value Validation ──────────────────────
+  // ── Credentials: Empty Key/Value Validation ────────────────────────
 
   test("new secret: empty key or value shows validation feedback", async ({ page }) => {
     const settings = new ConfigPage(page);
@@ -143,38 +143,5 @@ test.describe("Settings Interaction Smoke", () => {
     await modal.getByRole("button", { name: "Save secret" }).click();
     await page.waitForTimeout(300);
     expect(postSent).toBe(false);
-  });
-
-  // ── Tab Switching Preserves Content ──────────────────────────────────
-
-  test("credentials tab content persists after switching to Advanced and back", async ({ page }) => {
-    const settings = new ConfigPage(page);
-    await settings.navigateToSecrets();
-
-    await expect(page.getByText("LINEAR_API_KEY").first()).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText("OPENAI_API_KEY").first()).toBeVisible({ timeout: 5000 });
-
-    await settings.tabButton("Advanced").click();
-    await expect(settings.tabButton("Advanced")).toHaveAttribute("aria-selected", "true");
-
-    await settings.tabButton("Credentials").click();
-    await expect(settings.tabButton("Credentials")).toHaveAttribute("aria-selected", "true");
-
-    await expect(page.getByText("LINEAR_API_KEY").first()).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText("OPENAI_API_KEY").first()).toBeVisible({ timeout: 5000 });
-  });
-
-  test("advanced tab raw edits survive round-trip through General tab", async ({ page }) => {
-    const settings = new ConfigPage(page);
-    await settings.navigateToConfig();
-
-    await page.getByRole("button", { name: "Raw JSON" }).click();
-    const editor = page.locator(".config-textarea-large");
-    await editor.fill('{"my.draft":"persist-me"}');
-
-    await settings.tabButton("General").click();
-    await settings.tabButton("Advanced").click();
-
-    await expect(editor).toHaveValue('{"my.draft":"persist-me"}');
   });
 });

--- a/tests/frontend/command-palette-data.test.ts
+++ b/tests/frontend/command-palette-data.test.ts
@@ -59,10 +59,10 @@ describe("createBasePaletteEntries", () => {
     expect(entries.some((entry) => entry.id === "action:shortcuts")).toBe(true);
   });
 
-  it("includes direct entries for advanced settings and credentials", () => {
+  it("includes direct entries for devtools and credentials", () => {
     const entries = createBasePaletteEntries();
 
-    expect(entries.some((entry) => entry.id === "nav:/settings#advanced")).toBe(true);
+    expect(entries.some((entry) => entry.id === "nav:/settings#devtools")).toBe(true);
     expect(entries.some((entry) => entry.id === "nav:/settings#credentials")).toBe(true);
   });
 });

--- a/tests/frontend/settings-tabs.test.ts
+++ b/tests/frontend/settings-tabs.test.ts
@@ -2,26 +2,27 @@ import { describe, expect, it } from "vitest";
 
 import {
   normalizeLegacySettingsPath,
-  parseSettingsTabHash,
-  settingsPathForTab,
+  parseSettingsSectionHash,
+  settingsPathForSection,
 } from "../../frontend/src/utils/settings-tabs";
 
 describe("settings-tabs", () => {
-  it("parses known tab hashes and falls back to general", () => {
-    expect(parseSettingsTabHash("#advanced")).toBe("advanced");
-    expect(parseSettingsTabHash("#credentials")).toBe("credentials");
-    expect(parseSettingsTabHash("#unknown")).toBe("general");
-    expect(parseSettingsTabHash("")).toBe("general");
+  it("parses known section hashes and returns null for unknown", () => {
+    expect(parseSettingsSectionHash("#credentials")).toBe("credentials");
+    expect(parseSettingsSectionHash("#devtools")).toBe("devtools");
+    expect(parseSettingsSectionHash("#unknown")).toBeNull();
+    expect(parseSettingsSectionHash("#general")).toBeNull();
+    expect(parseSettingsSectionHash("")).toBeNull();
   });
 
-  it("maps tabs to settings URLs", () => {
-    expect(settingsPathForTab("general")).toBe("/settings#general");
-    expect(settingsPathForTab("credentials")).toBe("/settings#credentials");
-    expect(settingsPathForTab("advanced")).toBe("/settings#advanced");
+  it("maps sections to settings URLs", () => {
+    expect(settingsPathForSection(null)).toBe("/settings");
+    expect(settingsPathForSection("credentials")).toBe("/settings#credentials");
+    expect(settingsPathForSection("devtools")).toBe("/settings#devtools");
   });
 
   it("normalizes legacy config and secrets paths", () => {
-    expect(normalizeLegacySettingsPath("/config")).toBe("advanced");
+    expect(normalizeLegacySettingsPath("/config")).toBe("devtools");
     expect(normalizeLegacySettingsPath("/secrets")).toBe("credentials");
     expect(normalizeLegacySettingsPath("/settings")).toBeNull();
   });


### PR DESCRIPTION
## Summary

- **Removes the 3-tab settings shell** (General / Credentials / Advanced) and replaces it with a single scrollable page where all three sections are visible at once.
- **General settings** render at the top with the existing rail + content layout.
- **Credentials section** follows as a card panel with its own header and the "New secret" action button.
- **Developer Tools** lives in a collapsible `<details>` element at the bottom, defaulting to closed.
- **Fixes audit [A2]**: replaces `innerHTML` in `config-view.ts` help banner with DOM API calls and direct event binding.
- **Updates all hash references**: `#advanced` -> `#devtools` across router aliases, keyboard shortcuts, command palette, git-view, and welcome-view.
- Hash routing preserved: `#credentials` scrolls to credentials, `#devtools` opens and scrolls to dev tools. Legacy `/config` and `/secrets` paths still work.

## Files changed (14)
- `frontend/src/views/unified-settings-view.ts` — rewritten (289 -> 163 lines)
- `frontend/src/styles/unified-settings.css` — rewritten (tab styles -> section styles)
- `frontend/src/utils/settings-tabs.ts` — simplified (`SettingsTabId` -> `SettingsSectionHash`)
- `frontend/src/views/config-view.ts` — innerHTML replaced with DOM API
- `frontend/src/main.ts` — router alias updated
- `frontend/src/ui/keyboard.ts`, `command-palette-data.ts` — hash updated
- `frontend/src/views/git-view.ts`, `welcome-view.ts` — hash updated
- `tests/e2e/pages/config.page.ts` — POM updated (removed tab methods, added section locators)
- `tests/e2e/specs/smoke/config-secrets.smoke.spec.ts` — updated for unified layout
- `tests/e2e/specs/smoke/settings-interactions.smoke.spec.ts` — removed 2 tab-switching tests
- `tests/frontend/settings-tabs.test.ts` — updated for renamed functions
- `tests/frontend/command-palette-data.test.ts` — updated palette entry id

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors, 2 pre-existing warnings)
- [x] `npm run format:check` passes
- [x] `npm test` passes (1560 tests, 0 failures)
- [x] `npx playwright test --project=smoke` passes (84 tests, 0 failures)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
