### PR TITLE
feat(agent-runner): handle turn/plan/updated and commandExecution/outputDelta

### DIFF
--- a/src/agent-runner/notification-handler.ts
+++ b/src/agent-runner/notification-handler.ts
@@ -77,6 +77,21 @@ function handlePlanDelta(input: NotificationInput, params: Record<string, unknow
   appendReasoningText(input.state, asString(params.itemId), asString(delta.text) ?? asString(params.text));
 }
 
+function handleTurnPlanUpdated(input: NotificationInput, params: Record<string, unknown>): void {
+  const plan = asRecord(params.plan);
+  const steps = plan.steps;
+  input.onEvent({
+    at: new Date().toISOString(),
+    issueId: input.issue.id,
+    issueIdentifier: input.issue.identifier,
+    sessionId: composeSessionId(input.threadId, input.turnId),
+    event: "agent_plan",
+    message: "Agent plan updated",
+    content: typeof steps === "string" ? steps : JSON.stringify(steps),
+    metadata: { isPlan: true },
+  });
+}
+
 function handleTurnDiffUpdated(input: NotificationInput, params: Record<string, unknown>): void {
   const diff = asString(params.diff);
   if (!diff) {
@@ -153,6 +168,7 @@ const methodHandlers: Record<string, (input: NotificationInput, params: Record<s
   "item/reasoning/textDelta": handleReasoningDelta,
   "item/reasoning/summaryPartAdded": handleReasoningPartAdded,
   "item/plan/delta": handlePlanDelta,
+  "turn/plan/updated": handleTurnPlanUpdated,
 };
 
 export function handleNotification(input: NotificationInput): void {
@@ -204,6 +220,7 @@ const CODEX_NOTIFICATION_LABELS: Record<string, { event: string; message: string
   "account/rateLimits/updated": { event: "rate_limits", message: "API rate limits updated" },
   "item/agentMessage/delta": { event: "agent_streaming", message: "Agent streaming text" },
   "item/fileChange/outputDelta": { event: "tool_output", message: "File change output streaming" },
+  "item/commandExecution/outputDelta": { event: "tool_output", message: "Command output streaming" },
 };
 
 function mapCodexNotification(method: string, params: Record<string, unknown>): { event: string; message: string } {

--- a/tests/agent-runner/notification-handler.test.ts
+++ b/tests/agent-runner/notification-handler.test.ts
@@ -372,6 +372,7 @@ describe("handleNotification", () => {
       ["account/rateLimits/updated", "rate_limits", "API rate limits updated"],
       ["item/agentMessage/delta", "agent_streaming", "Agent streaming text"],
       ["item/fileChange/outputDelta", "tool_output", "File change output streaming"],
+      ["item/commandExecution/outputDelta", "tool_output", "Command output streaming"],
     ])("maps %s to event=%s, message=%s", (method, expectedEvent, expectedMessage) => {
       handleNotification({
         state,
@@ -541,6 +542,97 @@ describe("handleNotification", () => {
 
       expect(state.reasoningBuffers.get("plan-1")).toBe("Step 1: analyse the codebase");
       expect(events).toHaveLength(0); // deltas do not emit events
+    });
+  });
+
+  describe("turn/plan/updated", () => {
+    it("emits agent_plan with JSON-stringified steps", () => {
+      const steps = [{ title: "Step 1", status: "completed" }];
+      handleNotification({
+        state,
+        notification: {
+          method: "turn/plan/updated",
+          params: { plan: { steps } },
+        },
+        issue,
+        threadId: "thread-1",
+        turnId: "turn-1",
+        onEvent,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        at: FIXED_ISO,
+        issueId: "issue-1",
+        issueIdentifier: "ENG-42",
+        sessionId: "thread-1-turn-1",
+        event: "agent_plan",
+        message: "Agent plan updated",
+        metadata: { isPlan: true },
+      });
+      expect(events[0].content).toBe(JSON.stringify(steps));
+    });
+
+    it("passes string steps through directly", () => {
+      handleNotification({
+        state,
+        notification: {
+          method: "turn/plan/updated",
+          params: { plan: { steps: "1. Clone repo\n2. Run tests" } },
+        },
+        issue,
+        threadId: null,
+        turnId: null,
+        onEvent,
+      });
+
+      expect(events[0]).toMatchObject({
+        event: "agent_plan",
+        content: "1. Clone repo\n2. Run tests",
+      });
+    });
+
+    it("does not crash with empty plan params", () => {
+      handleNotification({
+        state,
+        notification: {
+          method: "turn/plan/updated",
+          params: {},
+        },
+        issue,
+        threadId: null,
+        turnId: null,
+        onEvent,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        event: "agent_plan",
+        message: "Agent plan updated",
+        metadata: { isPlan: true },
+      });
+    });
+  });
+
+  describe("item/commandExecution/outputDelta", () => {
+    it("maps to tool_output via the label fallback path", () => {
+      handleNotification({
+        state,
+        notification: {
+          method: "item/commandExecution/outputDelta",
+          params: { delta: { text: "output chunk" } },
+        },
+        issue,
+        threadId: "thread-1",
+        turnId: "turn-1",
+        onEvent,
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        event: "tool_output",
+        message: "Command output streaming",
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `handleTurnPlanUpdated` method handler that emits `agent_plan` events with plan steps (string passthrough or JSON-stringified objects)
- Register `item/commandExecution/outputDelta` in `CODEX_NOTIFICATION_LABELS` mapping to `tool_output` / "Command output streaming"
- Add comprehensive tests: plan with object steps, string steps, empty params resilience, and label-path mapping for commandExecution/outputDelta

## Test plan
- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run format:check` passes
- [x] `pnpm test` passes (1702 tests, 0 failures)
- [x] `pnpm run knip` clean (no new unused exports)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
