### PR TITLE
feat(agent-runner): add serviceName, optOut notifications, and configurable personality

### DIFF
--- a/src/agent-runner/session-init.ts
+++ b/src/agent-runner/session-init.ts
@@ -96,7 +96,17 @@ async function initCodexProtocol(
 ): Promise<{ kind: "failed"; errorCode: string; errorMessage: string } | null> {
   await session.connection.request("initialize", {
     clientInfo: { name: "symphony", version: "0.2.0" },
-    capabilities: { experimentalApi: true },
+    capabilities: {
+      experimentalApi: true,
+      optOutNotificationMethods: [
+        "thread/archived",
+        "thread/unarchived",
+        "thread/closed",
+        "serverRequest/resolved",
+        "app/list/updated",
+        "windowsSandbox/setupCompleted",
+      ],
+    },
   });
   session.connection.notify("initialized", {});
 
@@ -133,7 +143,8 @@ async function startThread(session: DockerSession, config: ServiceConfig, input:
     model: input.modelSelection.model,
     approvalPolicy: config.codex.approvalPolicy,
     sandbox: config.codex.threadSandbox,
-    personality: "friendly",
+    personality: config.codex.personality,
+    serviceName: "symphony",
     dynamicTools: buildDynamicTools(),
   });
 

--- a/src/config/builders.ts
+++ b/src/config/builders.ts
@@ -182,6 +182,7 @@ function deriveCodexConfig(
     reasoningEffort: asReasoningEffort(codex.reasoning_effort, "high"),
     approvalPolicy: normalizeApprovalPolicy(codex.approval_policy),
     threadSandbox: asString(codex.thread_sandbox, "workspace-write"),
+    personality: asString(codex.personality, "friendly"),
     turnSandboxPolicy: normalizeTurnSandboxPolicy(turnSandboxPolicyRecord),
     readTimeoutMs,
     turnTimeoutMs: asNumber(codex.turn_timeout_ms, 3600000),

--- a/src/config/schemas/codex.ts
+++ b/src/config/schemas/codex.ts
@@ -102,6 +102,7 @@ export const codexConfigSchema = z.object({
   reasoningEffort: reasoningEffortSchema.default("high"),
   approvalPolicy: approvalPolicySchema,
   threadSandbox: z.string().default("workspace-write"),
+  personality: z.string().default("friendly"),
   turnSandboxPolicy: turnSandboxPolicySchema,
   readTimeoutMs: z.number().default(5000),
   turnTimeoutMs: z.number().default(3600000),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -318,6 +318,7 @@ export interface CodexConfig {
   reasoningEffort: ReasoningEffort | null;
   approvalPolicy: string | Record<string, unknown>;
   threadSandbox: string;
+  personality: string;
   turnSandboxPolicy: { type: string; [key: string]: unknown };
   readTimeoutMs: number;
   turnTimeoutMs: number;

--- a/tests/agent-runner/session-init.test.ts
+++ b/tests/agent-runner/session-init.test.ts
@@ -311,6 +311,84 @@ describe("initializeSession", () => {
     });
   });
 
+  describe("initialize protocol params", () => {
+    it("sends optOutNotificationMethods in capabilities", async () => {
+      const session = makeMockSession();
+      session.connection.request
+        .mockResolvedValueOnce({}) // initialize
+        .mockResolvedValueOnce({ status: "authenticated" }) // account/read
+        .mockResolvedValueOnce({ rateLimits: [] }) // account/rateLimits/read
+        .mockResolvedValueOnce({ threadId: "thread-init" }); // thread/start
+
+      const input = makeInput();
+      const liquid = makeLiquid({ render: async () => "prompt" });
+
+      await initializeSession(session, makeMinimalConfig(), input, deps, liquid);
+
+      const initCall = session.connection.request.mock.calls[0];
+      expect(initCall[0]).toBe("initialize");
+      expect(initCall[1]).toMatchObject({
+        capabilities: {
+          experimentalApi: true,
+          optOutNotificationMethods: [
+            "thread/archived",
+            "thread/unarchived",
+            "thread/closed",
+            "serverRequest/resolved",
+            "app/list/updated",
+            "windowsSandbox/setupCompleted",
+          ],
+        },
+      });
+    });
+  });
+
+  describe("thread/start protocol params", () => {
+    it("sends serviceName: symphony", async () => {
+      const session = makeMockSession();
+      session.connection.request
+        .mockResolvedValueOnce({}) // initialize
+        .mockResolvedValueOnce({ status: "authenticated" }) // account/read
+        .mockResolvedValueOnce({ rateLimits: [] }) // account/rateLimits/read
+        .mockResolvedValueOnce({ threadId: "thread-svc" }); // thread/start
+
+      const input = makeInput();
+      const liquid = makeLiquid({ render: async () => "prompt" });
+
+      await initializeSession(session, makeMinimalConfig(), input, deps, liquid);
+
+      const threadCall = session.connection.request.mock.calls[3];
+      expect(threadCall[0]).toBe("thread/start");
+      expect(threadCall[1]).toMatchObject({ serviceName: "symphony" });
+    });
+
+    it("uses personality from config instead of hardcoded value", async () => {
+      const session = makeMockSession();
+      session.connection.request
+        .mockResolvedValueOnce({}) // initialize
+        .mockResolvedValueOnce({ status: "authenticated" }) // account/read
+        .mockResolvedValueOnce({ rateLimits: [] }) // account/rateLimits/read
+        .mockResolvedValueOnce({ threadId: "thread-p" }); // thread/start
+
+      const config = {
+        codex: {
+          approvalPolicy: "auto-edit",
+          threadSandbox: "none",
+          personality: "concise",
+        },
+      } as unknown as ServiceConfig;
+
+      const input = makeInput();
+      const liquid = makeLiquid({ render: async () => "prompt" });
+
+      await initializeSession(session, config, input, deps, liquid);
+
+      const threadCall = session.connection.request.mock.calls[3];
+      expect(threadCall[0]).toBe("thread/start");
+      expect(threadCall[1]).toMatchObject({ personality: "concise" });
+    });
+  });
+
   describe("thread/start failure", () => {
     it("throws when thread/start returns no thread identifier", async () => {
       const session = makeMockSession();

--- a/tests/config/schemas.test.ts
+++ b/tests/config/schemas.test.ts
@@ -94,6 +94,16 @@ describe("codexConfigSchema", () => {
     expect(result.provider).toBe(null);
   });
 
+  it("defaults personality to friendly", () => {
+    const result = codexConfigSchema.parse({});
+    expect(result.personality).toBe("friendly");
+  });
+
+  it("preserves custom personality value", () => {
+    const result = codexConfigSchema.parse({ personality: "concise" });
+    expect(result.personality).toBe("concise");
+  });
+
   it("applies default turn sandbox policy for empty input", () => {
     const result = codexConfigSchema.parse({});
     expect(result.turnSandboxPolicy.type).toBe("workspaceWrite");


### PR DESCRIPTION
## Summary
- Add `optOutNotificationMethods` array to the `initialize` capabilities, opting out of 6 notification methods Symphony does not handle (thread/archived, thread/unarchived, thread/closed, serverRequest/resolved, app/list/updated, windowsSandbox/setupCompleted)
- Add `serviceName: "symphony"` to the `thread/start` call for proper app-server API identification
- Make `personality` configurable via `codex.personality` config field (defaults to `"friendly"`) instead of hardcoding it in the session init

## Test plan
- [x] Schema test: `personality` defaults to `"friendly"` when not specified
- [x] Schema test: `personality` preserves custom value (e.g. `"concise"`)
- [x] Session init test: `initialize` call includes `optOutNotificationMethods` in capabilities
- [x] Session init test: `thread/start` includes `serviceName: "symphony"`
- [x] Session init test: `thread/start` uses personality from config, not hardcoded
- [x] Full gate: build + lint + format:check + test + knip all pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
