### PR TITLE
feat(agent): add graceful turn/interrupt before container kill

### DIFF
--- a/src/agent-runner/docker-session.ts
+++ b/src/agent-runner/docker-session.ts
@@ -161,8 +161,17 @@ function buildDockerSessionObject(
     getFatalFailure: () => fatalFailure,
     inspectRunning: helpers.inspectRunning,
     abortHandler: () => {
-      session.connection.close();
-      void stopContainer(containerName, 5);
+      void (async () => {
+        if (session.threadId && session.turnId) {
+          const interrupted = await session.connection.interruptTurn(session.threadId, session.turnId, 3000);
+          if (interrupted) {
+            // Allow time for turn/completed notification before hard kill
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+          }
+        }
+        session.connection.close();
+        void stopContainer(containerName, 5);
+      })();
     },
     statsInterval: null,
     cleanup: async (cfg: ServiceConfig, signal: AbortSignal) => {

--- a/src/agent/json-rpc-connection.ts
+++ b/src/agent/json-rpc-connection.ts
@@ -32,7 +32,11 @@ export class JsonRpcConnection {
       timer: NodeJS.Timeout;
     }
   >();
-  private exited = false;
+  private _exited = false;
+
+  get exited(): boolean {
+    return this._exited;
+  }
 
   constructor(
     private readonly child: ChildProcessWithoutNullStreams,
@@ -55,7 +59,7 @@ export class JsonRpcConnection {
       this.logger.error({ error: toErrorString(error) }, "unexpected stdin error");
     });
     child.on("exit", () => {
-      this.exited = true;
+      this._exited = true;
       for (const [id, pending] of this.pending) {
         clearTimeout(pending.timer);
         pending.reject(new Error(`connection exited while waiting for request ${id}`));
@@ -65,13 +69,26 @@ export class JsonRpcConnection {
   }
 
   close(): void {
-    if (!this.exited) {
+    if (!this._exited) {
       this.child.kill("SIGTERM");
     }
   }
 
+  async interruptTurn(threadId: string, turnId: string, timeoutMs = 3000): Promise<boolean> {
+    if (this._exited) return false;
+    try {
+      await Promise.race([
+        this.request("turn/interrupt", { threadId, turnId }),
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error("interrupt timeout")), timeoutMs)),
+      ]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   notify(method: string, params: unknown): void {
-    if (this.exited) {
+    if (this._exited) {
       return;
     }
     this.send({
@@ -82,7 +99,7 @@ export class JsonRpcConnection {
   }
 
   request(method: string, params: unknown): Promise<unknown> {
-    if (this.exited) {
+    if (this._exited) {
       return Promise.reject(new Error("connection already exited"));
     }
     const request = createRequest(method, params);
@@ -98,7 +115,7 @@ export class JsonRpcConnection {
   }
 
   private send(message: unknown): void {
-    if (this.exited) {
+    if (this._exited) {
       return;
     }
     this.child.stdin.write(`${JSON.stringify(message)}\n`);

--- a/tests/agent/json-rpc-connection.test.ts
+++ b/tests/agent/json-rpc-connection.test.ts
@@ -384,6 +384,90 @@ describe("JsonRpcConnection", () => {
     });
   });
 
+  describe("exited getter", () => {
+    it("returns false initially", () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+      expect(conn.exited).toBe(false);
+    });
+
+    it("returns true after child process exits", () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+      mock.exit();
+      expect(conn.exited).toBe(true);
+    });
+
+    it("returns true after close() is called", () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+      // close() sends SIGTERM; simulate the exit event that follows
+      conn.close();
+      mock.exit();
+      expect(conn.exited).toBe(true);
+    });
+  });
+
+  describe("interruptTurn()", () => {
+    it("sends turn/interrupt request and returns true on success", async () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      const promise = conn.interruptTurn("thread-1", "turn-1", 5000);
+
+      // The interruptTurn method calls request(), which writes to stdin
+      const sent = lastSentMessage(mock);
+      expect(sent.method).toBe("turn/interrupt");
+      expect(sent.params).toEqual({ threadId: "thread-1", turnId: "turn-1" });
+
+      // Respond successfully
+      mock.sendLine({ jsonrpc: "2.0", id: sent.id, result: {} });
+      const result = await promise;
+      expect(result).toBe(true);
+    });
+
+    it("returns false when the request times out", async () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      const promise = conn.interruptTurn("thread-1", "turn-1", 500);
+
+      // Do not respond — let the interrupt timeout fire
+      vi.advanceTimersByTime(501);
+      const result = await promise;
+      expect(result).toBe(false);
+    });
+
+    it("returns false immediately when connection already exited", async () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      mock.exit();
+      const result = await conn.interruptTurn("thread-1", "turn-1");
+      expect(result).toBe(false);
+      // No new writes should have been sent after exit
+      const writesAfterExit = mock.child.stdin.write.mock.calls.length;
+      expect(writesAfterExit).toBe(0);
+    });
+
+    it("returns false when the request rejects with an error", async () => {
+      const mock = makeMockChild();
+      const conn = createConnection(mock);
+
+      const promise = conn.interruptTurn("thread-1", "turn-1", 5000);
+      const sent = lastSentMessage(mock);
+
+      // Respond with a JSON-RPC error
+      mock.sendLine({
+        jsonrpc: "2.0",
+        id: sent.id,
+        error: { code: -32600, message: "not supported" },
+      });
+      const result = await promise;
+      expect(result).toBe(false);
+    });
+  });
+
   describe("stdin error handling", () => {
     it("logs EPIPE as debug (child already exited)", () => {
       const mock = makeMockChild();


### PR DESCRIPTION
## Summary

- Add `interruptTurn()` method to `JsonRpcConnection` that sends a `turn/interrupt` JSON-RPC request with a configurable timeout, returning `true` on success and `false` on timeout/error/exit
- Expose a public `exited` getter on `JsonRpcConnection` so callers can check connection state before sending
- Update the Docker session abort handler to attempt graceful `turn/interrupt` before falling back to `connection.close()` + `stopContainer()`, giving Codex agents a chance to wind down cleanly

## Test plan

- [x] `exited` getter: returns false initially, true after child exits, true after close+exit
- [x] `interruptTurn` success: sends correct JSON-RPC request and returns true
- [x] `interruptTurn` timeout: returns false when request hangs past timeout
- [x] `interruptTurn` already exited: returns false immediately, no writes sent
- [x] `interruptTurn` error: returns false on JSON-RPC error response
- [x] Full CI gate: build, lint, format, tests (1704 passed), knip
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
