### PR TITLE
fix(agent): make unknown codex request methods non-fatal

### DIFF
--- a/src/agent/codex-request-handler.ts
+++ b/src/agent/codex-request-handler.ts
@@ -68,17 +68,21 @@ export async function handleCodexRequest(
     case "item/tool/call":
       return handleToolCall(asRecord(request.params), linearClient, githubToolClient);
     case "item/tool/requestUserInput":
-      return fatalResult(
-        "turn_input_required",
-        "codex requested interactive user input, which Symphony does not support",
-      );
+      return {
+        response: { result: null },
+        fatalFailure: null,
+      };
     case "mcpServer/elicitation/request":
       return fatalResult("startup_failed", "thread/start failed because a required MCP server did not initialize");
     case "account/chatgptAuthTokens/refresh":
+      return fatalResult("auth_token_expired", "ChatGPT auth token expired and Symphony cannot refresh it");
     case "applyPatchApproval":
     case "execCommandApproval":
       return fatalResult("startup_failed", `unsupported interactive request from codex: ${request.method}`);
     default:
-      return fatalResult("startup_failed", `unsupported codex request method: ${request.method}`);
+      return {
+        response: { error: { code: -32601, message: `unknown request method: ${request.method}` } },
+        fatalFailure: null,
+      };
   }
 }

--- a/src/orchestrator/views.ts
+++ b/src/orchestrator/views.ts
@@ -5,15 +5,9 @@ export function nowIso(): string {
 }
 
 export function isHardFailure(errorCode: string | null): boolean {
-  return [
-    "startup_failed",
-    "turn_input_required",
-    "inactive",
-    "terminal",
-    "shutdown",
-    "cancelled",
-    "auth_token_expired",
-  ].includes(errorCode ?? "");
+  return ["startup_failed", "inactive", "terminal", "shutdown", "cancelled", "auth_token_expired"].includes(
+    errorCode ?? "",
+  );
 }
 
 export function issueView(issue: Issue, extra?: Partial<RuntimeIssueView>): RuntimeIssueView {

--- a/tests/agent-runner/agent-runner.test.ts
+++ b/tests/agent-runner/agent-runner.test.ts
@@ -483,7 +483,7 @@ describe("AgentRunner", () => {
     });
   });
 
-  it("fails hard on interactive user input requests", async () => {
+  it("gracefully skips interactive user input requests and completes turn", async () => {
     const tempDir = await createTempDir();
     const { runner, workspaceManager } = await createRunner(tempDir, "user_input");
     const workspace = await workspaceManager.ensureWorkspace("MT-42");
@@ -502,14 +502,8 @@ describe("AgentRunner", () => {
       onEvent: () => undefined,
     });
 
-    expect(outcome).toEqual({
-      kind: "failed",
-      errorCode: "turn_input_required",
-      errorMessage: "codex requested interactive user input, which Symphony does not support",
-      threadId: "thread-1",
-      turnId: null,
-      turnCount: 1,
-    });
+    expect(outcome.kind).toBe("normal");
+    expect(outcome.threadId).toBe("thread-1");
   });
 
   it("classifies template parse failures explicitly", async () => {

--- a/tests/agent/codex-request-handler.test.ts
+++ b/tests/agent/codex-request-handler.test.ts
@@ -150,13 +150,10 @@ describe("handleCodexRequest", () => {
   });
 
   describe("fatal failure classification", () => {
-    it("marks user input request as turn_input_required", async () => {
+    it("gracefully skips user input request without fatal failure", async () => {
       const result = await handleCodexRequest(makeRequest("item/tool/requestUserInput"), mockLinearClient());
-      expect(result.fatalFailure).toEqual({
-        code: "turn_input_required",
-        message: expect.stringContaining("interactive user input"),
-      });
-      expect(result.response).toBeUndefined();
+      expect(result.fatalFailure).toBeNull();
+      expect(result.response).toEqual({ result: null });
     });
 
     it("marks MCP elicitation as startup_failed", async () => {
@@ -167,11 +164,11 @@ describe("handleCodexRequest", () => {
       });
     });
 
-    it("marks chatgpt token refresh as startup_failed", async () => {
+    it("marks chatgpt token refresh as auth_token_expired", async () => {
       const result = await handleCodexRequest(makeRequest("account/chatgptAuthTokens/refresh"), mockLinearClient());
       expect(result.fatalFailure).toEqual({
-        code: "startup_failed",
-        message: expect.stringContaining("unsupported interactive request"),
+        code: "auth_token_expired",
+        message: expect.stringContaining("auth token expired"),
       });
     });
 
@@ -187,17 +184,19 @@ describe("handleCodexRequest", () => {
   });
 
   describe("unsupported method fallback", () => {
-    it("returns startup_failed for completely unknown methods", async () => {
+    it("returns non-fatal JSON-RPC method-not-found error for unknown methods", async () => {
       const result = await handleCodexRequest(makeRequest("some/totally/unknown/method"), mockLinearClient());
-      expect(result.fatalFailure).toEqual({
-        code: "startup_failed",
-        message: expect.stringContaining("unsupported codex request method"),
-      });
+      expect(result.fatalFailure).toBeNull();
+      const response = result.response as { error: { code: number; message: string } };
+      expect(response.error.code).toBe(-32601);
+      expect(response.error.message).toContain("unknown request method");
     });
 
-    it("includes the unknown method name in the error message", async () => {
+    it("includes the unknown method name in the error response", async () => {
       const result = await handleCodexRequest(makeRequest("custom/method"), mockLinearClient());
-      expect(result.fatalFailure?.message).toContain("custom/method");
+      expect(result.fatalFailure).toBeNull();
+      const response = result.response as { error: { code: number; message: string } };
+      expect(response.error.message).toContain("custom/method");
     });
   });
 });

--- a/tests/fixtures/mock-codex-server.mjs
+++ b/tests/fixtures/mock-codex-server.mjs
@@ -164,6 +164,7 @@ async function onClientRequest(message) {
     case "turn/start":
       if (scenario === "user_input") {
         sendRequest("item/tool/requestUserInput", { prompt: "Need input" }).catch(() => undefined);
+        startSuccessTurnSequence(message.id);
         return;
       }
       if (scenario === "hang_turn") {

--- a/tests/orchestrator/views.test.ts
+++ b/tests/orchestrator/views.test.ts
@@ -23,14 +23,22 @@ function makeIssue(overrides: Partial<Issue> = {}): Issue {
 
 describe("isHardFailure", () => {
   it("returns true for known hard failure codes", () => {
-    const hardCodes = ["startup_failed", "turn_input_required", "inactive", "terminal", "shutdown", "cancelled"];
+    const hardCodes = ["startup_failed", "inactive", "terminal", "shutdown", "cancelled", "auth_token_expired"];
     for (const code of hardCodes) {
       expect(isHardFailure(code), `expected ${code} to be a hard failure`).toBe(true);
     }
   });
 
   it("returns false for retryable codes", () => {
-    const retryCodes = ["turn_failed", "port_exit", "turn_timeout", "read_timeout", "startup_timeout", "container_oom"];
+    const retryCodes = [
+      "turn_failed",
+      "port_exit",
+      "turn_timeout",
+      "read_timeout",
+      "startup_timeout",
+      "container_oom",
+      "turn_input_required",
+    ];
     for (const code of retryCodes) {
       expect(isHardFailure(code), `expected ${code} to not be a hard failure`).toBe(false);
     }


### PR DESCRIPTION
## Summary

- **Unknown Codex request methods** now return a JSON-RPC `-32601` "method not found" error response instead of a fatal `startup_failed` that killed all running sessions. This means when Codex adds new request types, Symphony degrades gracefully instead of crashing.
- **`item/tool/requestUserInput`** now returns a graceful null skip (`{ result: null }`) instead of a fatal `turn_input_required` error. Interactive input is unsupported but not session-ending.
- **`account/chatgptAuthTokens/refresh`** now uses the `auth_token_expired` error code instead of generic `startup_failed`, enabling smarter retry classification downstream.
- **`isHardFailure`** in `views.ts` updated: removed `turn_input_required` (no longer produced), `auth_token_expired` was already present.

## Files changed

| File | Change |
|------|--------|
| `src/agent/codex-request-handler.ts` | Three handler changes (default, requestUserInput, chatgptAuthTokens) |
| `src/orchestrator/views.ts` | Remove `turn_input_required` from hard failure list |
| `tests/agent/codex-request-handler.test.ts` | Updated assertions for all three changed behaviors |
| `tests/orchestrator/views.test.ts` | Updated hard/retryable code expectations |
| `tests/agent-runner/agent-runner.test.ts` | Updated integration test: requestUserInput now completes normally |
| `tests/fixtures/mock-codex-server.mjs` | Mock now completes turn after requestUserInput (matches new behavior) |

## Test plan

- [x] All 1697 unit tests pass
- [x] Build, lint, format, knip all green
- [x] codex-request-handler tests verify: unknown methods return -32601 non-fatal, requestUserInput returns null non-fatal, chatgptAuthTokens returns auth_token_expired fatal
- [x] views tests verify: auth_token_expired is hard failure, turn_input_required is not
- [x] agent-runner integration test verifies requestUserInput scenario completes turn normally
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
