### PR TITLE
feat(agent-runner): add summary concise and structured output schema to turn/start

### DIFF
--- a/src/agent-runner/turn-executor.ts
+++ b/src/agent-runner/turn-executor.ts
@@ -22,6 +22,15 @@ import type { RunOutcome } from "../core/types.js";
 const CONTINUATION_PROMPT =
   "Continue the current issue, make concrete progress, and stop only when done or blocked. When the issue is complete, end your final message with `SYMPHONY_STATUS: DONE`. If you are blocked and cannot proceed, end your final message with `SYMPHONY_STATUS: BLOCKED`.";
 
+const STRUCTURED_OUTPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    status: { type: "string", enum: ["DONE", "BLOCKED", "CONTINUE"] },
+    summary: { type: "string" },
+  },
+  required: ["status", "summary"],
+} as const;
+
 function checkFatalFailure(state: AgentRunnerTurnExecutionState): RunOutcome | null {
   return failureOutcome(state.getFatalFailure(), state.threadId, state.turnId, state.turnCount);
 }
@@ -98,7 +107,9 @@ async function runSingleTurn(
     effort: input.runInput.modelSelection.reasoningEffort,
     approvalPolicy: input.config.codex.approvalPolicy,
     sandboxPolicy: getTurnSandboxPolicy(input.config, input.runInput.workspace.path),
+    summary: "concise",
     input: [{ type: "text", text: prompt }],
+    ...(input.config.codex.structuredOutput ? { outputSchema: STRUCTURED_OUTPUT_SCHEMA } : {}),
   });
   state.turnId = extractTurnId(turnResult);
   if (!state.turnId) {

--- a/src/config/builders.ts
+++ b/src/config/builders.ts
@@ -188,6 +188,7 @@ function deriveCodexConfig(
     drainTimeoutMs: asNumber(codex.drain_timeout_ms, 2000),
     startupTimeoutMs: asNumber(codex.startup_timeout_ms, 30000),
     stallTimeoutMs,
+    structuredOutput: asBoolean(codex.structured_output, false),
     auth: {
       mode: asCodexAuthMode(auth.mode, "api_key"),
       sourceHome: resolveConfigString(asString(auth.source_home, "~/.codex"), secretResolver),

--- a/src/config/schemas/codex.ts
+++ b/src/config/schemas/codex.ts
@@ -108,6 +108,7 @@ export const codexConfigSchema = z.object({
   drainTimeoutMs: z.number().default(2000),
   startupTimeoutMs: z.number().default(30000),
   stallTimeoutMs: z.number().default(300000),
+  structuredOutput: z.boolean().default(false),
   auth: codexAuthSchema.default(() => codexAuthSchema.parse({})),
   provider: codexProviderSchema,
   sandbox: sandboxConfigSchema.default(() => sandboxConfigSchema.parse({})),

--- a/src/core/signal-detection.ts
+++ b/src/core/signal-detection.ts
@@ -11,6 +11,18 @@ export function detectStopSignal(content: string | null): StopSignal | null {
     return null;
   }
 
+  // Try structured JSON first (outputSchema responses)
+  try {
+    const parsed: unknown = JSON.parse(content.trim());
+    if (parsed && typeof parsed === "object" && "status" in parsed) {
+      const status = String((parsed as Record<string, unknown>).status).toUpperCase();
+      if (status === "DONE") return "done";
+      if (status === "BLOCKED") return "blocked";
+    }
+  } catch {
+    // Not JSON — fall through to text pattern matching
+  }
+
   const normalized = normalizeForDetection(content);
   if (normalized.includes("symphony_status: done") || normalized.includes("symphony status: done")) {
     return "done";

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -324,6 +324,7 @@ export interface CodexConfig {
   drainTimeoutMs: number;
   startupTimeoutMs: number;
   stallTimeoutMs: number;
+  structuredOutput: boolean;
   auth: CodexAuthConfig;
   provider: CodexProviderConfig | null;
   sandbox: SandboxConfig;

--- a/tests/agent-runner/signal-detection.test.ts
+++ b/tests/agent-runner/signal-detection.test.ts
@@ -38,4 +38,32 @@ describe("detectStopSignal", () => {
       "SYMPHONY_STATUS: DONE";
     expect(detectStopSignal(longMessage)).toBe("done");
   });
+
+  describe("structured JSON output", () => {
+    it("returns 'done' for JSON with status DONE", () => {
+      expect(detectStopSignal('{"status":"DONE","summary":"completed"}')).toBe("done");
+    });
+
+    it("returns 'blocked' for JSON with status BLOCKED", () => {
+      expect(detectStopSignal('{"status":"BLOCKED","summary":"stuck"}')).toBe("blocked");
+    });
+
+    it("returns null for JSON with status CONTINUE", () => {
+      expect(detectStopSignal('{"status":"CONTINUE","summary":"working"}')).toBeNull();
+    });
+
+    it("is case-insensitive for JSON status", () => {
+      expect(detectStopSignal('{"status":"done"}')).toBe("done");
+      expect(detectStopSignal('{"status":"Done"}')).toBe("done");
+      expect(detectStopSignal('{"status":"blocked"}')).toBe("blocked");
+    });
+
+    it("falls through to text matching for malformed JSON", () => {
+      expect(detectStopSignal("{bad json SYMPHONY_STATUS: DONE")).toBe("done");
+    });
+
+    it("falls through to text matching for JSON without status field", () => {
+      expect(detectStopSignal('{"result":"ok"}\nSYMPHONY_STATUS: BLOCKED')).toBe("blocked");
+    });
+  });
 });

--- a/tests/agent-runner/turn-executor.test.ts
+++ b/tests/agent-runner/turn-executor.test.ts
@@ -299,4 +299,51 @@ describe("executeTurns", () => {
     expect(result.kind).toBe("cancelled");
     expect(result.errorCode).toBe("shutdown");
   });
+
+  it("includes summary: 'concise' in turn/start request", async () => {
+    vi.mocked(isActiveState).mockReturnValueOnce(false);
+
+    const input = makeInput();
+    const state = makeState();
+
+    await executeTurns(input, state);
+
+    const requestMock = (input.connection as { request: ReturnType<typeof vi.fn> }).request;
+    const params = requestMock.mock.calls[0][1];
+    expect(params.summary).toBe("concise");
+  });
+
+  it("includes outputSchema when structuredOutput is true", async () => {
+    vi.mocked(isActiveState).mockReturnValueOnce(false);
+
+    const input = makeInput();
+    (input.config.codex as { structuredOutput: boolean }).structuredOutput = true;
+    const state = makeState();
+
+    await executeTurns(input, state);
+
+    const requestMock = (input.connection as { request: ReturnType<typeof vi.fn> }).request;
+    const params = requestMock.mock.calls[0][1];
+    expect(params.outputSchema).toEqual({
+      type: "object",
+      properties: {
+        status: { type: "string", enum: ["DONE", "BLOCKED", "CONTINUE"] },
+        summary: { type: "string" },
+      },
+      required: ["status", "summary"],
+    });
+  });
+
+  it("does not include outputSchema when structuredOutput is false", async () => {
+    vi.mocked(isActiveState).mockReturnValueOnce(false);
+
+    const input = makeInput();
+    const state = makeState();
+
+    await executeTurns(input, state);
+
+    const requestMock = (input.connection as { request: ReturnType<typeof vi.fn> }).request;
+    const params = requestMock.mock.calls[0][1];
+    expect(params.outputSchema).toBeUndefined();
+  });
 });

--- a/tests/config/schemas.test.ts
+++ b/tests/config/schemas.test.ts
@@ -105,6 +105,16 @@ describe("codexConfigSchema", () => {
     });
     expect(result.turnSandboxPolicy.type).toBe("dangerFullAccess");
   });
+
+  it("defaults structuredOutput to false", () => {
+    const result = codexConfigSchema.parse({});
+    expect(result.structuredOutput).toBe(false);
+  });
+
+  it("accepts structuredOutput: true", () => {
+    const result = codexConfigSchema.parse({ structuredOutput: true });
+    expect(result.structuredOutput).toBe(true);
+  });
 });
 
 describe("sandboxConfigSchema", () => {


### PR DESCRIPTION
## Summary
- Adds `summary: "concise"` to all `turn/start` requests to reduce token usage on every turn
- Adds `structuredOutput` boolean config flag (default: `false`) to the codex config schema
- When `structuredOutput` is enabled, includes an `outputSchema` in `turn/start` for structured stop signal detection (status: DONE/BLOCKED/CONTINUE + summary)
- Extends `detectStopSignal` to parse structured JSON responses before falling back to text pattern matching

## Test plan
- [x] Schema test: `structuredOutput` defaults to `false` and accepts `true`
- [x] Turn executor test: `summary: "concise"` is always present in `turn/start` params
- [x] Turn executor test: `outputSchema` included when `structuredOutput` is `true`
- [x] Turn executor test: `outputSchema` absent when `structuredOutput` is `false`
- [x] Signal detection: JSON `{"status":"DONE","summary":"..."}` returns `"done"`
- [x] Signal detection: JSON `{"status":"BLOCKED","summary":"..."}` returns `"blocked"`
- [x] Signal detection: JSON `{"status":"CONTINUE","summary":"..."}` returns `null`
- [x] Signal detection: case-insensitive JSON status matching
- [x] Signal detection: malformed JSON falls through to text pattern matching
- [x] All 1708 existing tests still pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
