### PR TITLE
feat(agent-runner): add preflight command execution via command/exec

### DIFF
--- a/src/agent-runner/preflight.ts
+++ b/src/agent-runner/preflight.ts
@@ -1,0 +1,48 @@
+import type { SymphonyLogger } from "../core/types.js";
+import { asRecord } from "./helpers.js";
+import { toErrorString } from "../utils/type-guards.js";
+
+/** Minimal interface for the JSON-RPC request method used by preflight. */
+export interface PreflightConnection {
+  request(method: string, params: unknown): Promise<unknown>;
+}
+
+export interface PreflightResult {
+  passed: boolean;
+  failedCommand?: string;
+  output?: string;
+}
+
+export async function runPreflight(
+  connection: PreflightConnection,
+  commands: string[],
+  logger: SymphonyLogger,
+): Promise<PreflightResult> {
+  if (commands.length === 0) {
+    return { passed: true };
+  }
+
+  for (const command of commands) {
+    try {
+      const result = await connection.request("command/exec", { command });
+      const data = asRecord(result);
+      const exitCode = typeof data.exitCode === "number" ? data.exitCode : -1;
+      if (exitCode !== 0) {
+        logger.warn({ command, exitCode }, "preflight command failed");
+        return {
+          passed: false,
+          failedCommand: command,
+          output: typeof data.output === "string" ? data.output : undefined,
+        };
+      }
+    } catch (error) {
+      logger.warn({ command, error: toErrorString(error) }, "preflight command/exec request failed");
+      return {
+        passed: false,
+        failedCommand: command,
+      };
+    }
+  }
+
+  return { passed: true };
+}

--- a/src/config/schemas/agent.ts
+++ b/src/config/schemas/agent.ts
@@ -12,4 +12,5 @@ export const agentConfigSchema = z.object({
   maxContinuationAttempts: z.number().default(5),
   successState: z.string().nullable().default(null),
   stallTimeoutMs: z.number().default(1200000),
+  preflightCommands: z.array(z.string()).default([]),
 });

--- a/tests/agent-runner/preflight.test.ts
+++ b/tests/agent-runner/preflight.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PreflightConnection } from "../../src/agent-runner/preflight.js";
+import { runPreflight } from "../../src/agent-runner/preflight.js";
+import { createMockLogger } from "../helpers.js";
+
+function mockConnection(
+  impl?: (...args: unknown[]) => Promise<unknown>,
+): PreflightConnection & { request: ReturnType<typeof vi.fn> } {
+  return { request: impl ? vi.fn().mockImplementation(impl) : vi.fn() };
+}
+
+describe("runPreflight", () => {
+  const logger = createMockLogger();
+
+  it("passes with empty command list", async () => {
+    const connection = mockConnection();
+    const result = await runPreflight(connection, [], logger);
+    expect(result.passed).toBe(true);
+    expect(connection.request).not.toHaveBeenCalled();
+  });
+
+  it("passes when all commands succeed", async () => {
+    const connection = mockConnection(() => Promise.resolve({ exitCode: 0, output: "ok" }));
+    const result = await runPreflight(connection, ["npm test", "npm run lint"], logger);
+    expect(result.passed).toBe(true);
+    expect(connection.request).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails when a command returns non-zero exit code", async () => {
+    const connection = mockConnection(() => Promise.resolve({ exitCode: 1, output: "test failed" }));
+    const result = await runPreflight(connection, ["npm test"], logger);
+    expect(result.passed).toBe(false);
+    expect(result.failedCommand).toBe("npm test");
+    expect(result.output).toBe("test failed");
+  });
+
+  it("fails when command/exec throws", async () => {
+    const connection = mockConnection(() => Promise.reject(new Error("command/exec not supported")));
+    const result = await runPreflight(connection, ["npm test"], logger);
+    expect(result.passed).toBe(false);
+    expect(result.failedCommand).toBe("npm test");
+  });
+
+  it("stops at first failing command", async () => {
+    const connection = mockConnection();
+    connection.request.mockResolvedValueOnce({ exitCode: 0 }).mockResolvedValueOnce({ exitCode: 1 });
+    const result = await runPreflight(connection, ["cmd1", "cmd2", "cmd3"], logger);
+    expect(result.passed).toBe(false);
+    expect(result.failedCommand).toBe("cmd2");
+    expect(connection.request).toHaveBeenCalledTimes(2); // cmd3 never called
+  });
+});

--- a/tests/config/schemas.test.ts
+++ b/tests/config/schemas.test.ts
@@ -77,6 +77,14 @@ describe("agentConfigSchema", () => {
     expect(result.maxContinuationAttempts).toBe(5);
     expect(result.successState).toBe(null);
     expect(result.stallTimeoutMs).toBe(1200000);
+    expect(result.preflightCommands).toEqual([]);
+  });
+
+  it("accepts preflightCommands array", () => {
+    const result = agentConfigSchema.parse({
+      preflightCommands: ["npm test", "npm run lint"],
+    });
+    expect(result.preflightCommands).toEqual(["npm test", "npm run lint"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `runPreflight()` in `src/agent-runner/preflight.ts` that runs pre-flight validation commands inside the sandbox before starting a turn, using the Codex `command/exec` JSON-RPC method
- Commands execute sequentially with fail-fast on first non-zero exit code or RPC error
- Add `preflightCommands` field to the agent config schema (`z.array(z.string()).default([])`)
- Uses a minimal `PreflightConnection` interface instead of the full `JsonRpcConnection` class for better testability

## Test plan
- [x] Unit tests for `runPreflight()` covering: empty list (no-op), all-pass, non-zero exit, RPC throw, fail-fast stop
- [x] Schema tests for `preflightCommands` default and explicit values
- [x] Build passes (`pnpm run build`)
- [x] Lint passes (`pnpm run lint` -- 0 errors)
- [x] Format passes (`pnpm run format:check`)
- [x] All 1703 tests pass (`pnpm test`)
- [x] Knip passes (no dead exports)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
