### PR TITLE
feat(http): add turn/steer API endpoint for mid-turn guidance

### DIFF
--- a/src/agent-runner/docker-session.ts
+++ b/src/agent-runner/docker-session.ts
@@ -58,6 +58,7 @@ export interface DockerSession {
   getFatalFailure: () => { code: string; message: string } | null;
   inspectRunning: () => Promise<boolean | null>;
   cleanup: (config: ServiceConfig, signal: AbortSignal) => Promise<void>;
+  steerTurn: (message: string) => Promise<boolean>;
 }
 
 export async function createDockerSession(
@@ -165,6 +166,19 @@ function buildDockerSessionObject(
       void stopContainer(containerName, 5);
     },
     statsInterval: null,
+    steerTurn: async (message: string): Promise<boolean> => {
+      if (!session.threadId || !session.turnId) return false;
+      try {
+        await session.connection.request("turn/steer", {
+          threadId: session.threadId,
+          turnId: session.turnId,
+          message,
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    },
     cleanup: async (cfg: ServiceConfig, signal: AbortSignal) => {
       if (session.statsInterval) clearInterval(session.statsInterval);
       signal.removeEventListener("abort", session.abortHandler);

--- a/src/agent-runner/index.ts
+++ b/src/agent-runner/index.ts
@@ -46,6 +46,8 @@ export class AgentRunner implements RunAttemptDispatcher {
     workspace: Workspace;
     signal: AbortSignal;
     onEvent: AgentRunnerEventHandler;
+    /** Called once the session is ready with a function to steer the active turn. */
+    onSteerReady?: (steerTurn: (message: string) => Promise<boolean>) => void;
     /** Pre-computed runtime config for data plane (skips auth.json read) */
     precomputedRuntimeConfig?: PrecomputedRuntimeConfig;
   }): Promise<RunOutcome> {
@@ -106,6 +108,8 @@ export class AgentRunner implements RunAttemptDispatcher {
       );
       throw error;
     }
+
+    input.onSteerReady?.(session.steerTurn);
 
     try {
       return await this.executeSession(session, config, inputWithContentCapture, () => lastAgentMessageContent);

--- a/src/dispatch/types.ts
+++ b/src/dispatch/types.ts
@@ -31,6 +31,8 @@ export interface RunAttemptDispatcher {
     workspace: Workspace;
     signal: AbortSignal;
     onEvent: AgentRunnerEventHandler;
+    /** Called once the session is ready with a function to steer the active turn. */
+    onSteerReady?: (steerTurn: (message: string) => Promise<boolean>) => void;
   }): Promise<RunOutcome>;
 }
 

--- a/src/http/request-schemas.ts
+++ b/src/http/request-schemas.ts
@@ -46,3 +46,14 @@ export const transitionSchema = z
   .strict();
 
 export type TransitionBody = z.infer<typeof transitionSchema>;
+
+/**
+ * POST /:issue_identifier/steer
+ *
+ * Injects mid-turn guidance into a running agent session.
+ */
+export const steerSchema = z
+  .object({
+    message: z.string().min(1, "message is required"),
+  })
+  .strict();

--- a/src/http/routes.ts
+++ b/src/http/routes.ts
@@ -21,7 +21,7 @@ import { handleAttemptDetail } from "./attempt-handler.js";
 import { handleGitContext } from "./git-context.js";
 import { handleModelUpdate } from "./model-handler.js";
 import { getOpenApiSpec } from "./openapi.js";
-import { modelUpdateSchema, transitionSchema } from "./request-schemas.js";
+import { modelUpdateSchema, steerSchema, transitionSchema } from "./request-schemas.js";
 import { methodNotAllowed, refreshReason, sanitizeConfigValue, serializeSnapshot } from "./route-helpers.js";
 import { createSSEHandler } from "./sse.js";
 import { getSwaggerHtml } from "./swagger-html.js";
@@ -212,6 +212,20 @@ function registerIssueRoutes(app: Express, deps: HttpRouteDeps): void {
         req,
         res,
       );
+    })
+    .all((_req, res) => {
+      methodNotAllowed(res);
+    });
+
+  app
+    .route("/api/v1/:issue_identifier/steer")
+    .post(validateBody(steerSchema), async (req, res) => {
+      const result = await deps.orchestrator.steerIssue(req.params.issue_identifier, req.body.message);
+      if (!result) {
+        res.status(404).json({ error: { code: "not_found", message: "issue not running" } });
+        return;
+      }
+      res.json({ ok: result.ok, message: result.ok ? "steer sent" : "steer failed" });
     })
     .all((_req, res) => {
       methodNotAllowed(res);

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -175,6 +175,15 @@ export class Orchestrator implements OrchestratorPort {
     return result;
   }
 
+  async steerIssue(identifier: string, message: string): Promise<{ ok: boolean } | null> {
+    const entry = [...this._state.runningEntries.values()].find(
+      (runningEntry) => runningEntry.issue.identifier === identifier,
+    );
+    if (!entry?.steerTurn) return null;
+    const ok = await entry.steerTurn(message);
+    return { ok };
+  }
+
   private scheduleTick(delayMs: number): void {
     if (!this._state.running || this.tickInFlight) return;
     if (this.nextTickTimer) clearTimeout(this.nextTickTimer);

--- a/src/orchestrator/port.ts
+++ b/src/orchestrator/port.ts
@@ -18,4 +18,5 @@ export interface OrchestratorPort {
     model: string;
     reasoningEffort: ReasoningEffort | null;
   }): Promise<{ updated: boolean; restarted: boolean; appliesNextAttempt: boolean; selection: ModelSelection } | null>;
+  steerIssue(identifier: string, message: string): Promise<{ ok: boolean } | null>;
 }

--- a/src/orchestrator/runtime-types.ts
+++ b/src/orchestrator/runtime-types.ts
@@ -35,6 +35,7 @@ export interface RunningEntry {
   repoMatch: RepoMatch | null;
   queuePersistence: (task: () => Promise<void>) => void;
   flushPersistence: () => Promise<void>;
+  steerTurn?: (message: string) => Promise<boolean>;
 }
 
 export type RetryRuntimeEntry = RetryEntry & { issue: Issue; workspaceKey: string | null };

--- a/src/orchestrator/worker-launcher.ts
+++ b/src/orchestrator/worker-launcher.ts
@@ -320,6 +320,9 @@ export async function launchWorker(
     workspace,
     signal: entry.abortController.signal,
     onEvent: buildOnEventHandler(ctx, entry),
+    onSteerReady: (steerFn) => {
+      entry.steerTurn = steerFn;
+    },
   });
   entry.promise = ctx.handleWorkerPromise(promise, issue, workspace, entry, attempt);
 }

--- a/tests/http/routes.test.ts
+++ b/tests/http/routes.test.ts
@@ -27,6 +27,7 @@ function makeOrchestrator() {
     getAttemptDetail: vi.fn().mockReturnValue(null),
     abortIssue: vi.fn().mockReturnValue({ ok: false, code: "not_found", message: "Unknown issue identifier" }),
     updateIssueModelSelection: vi.fn().mockResolvedValue(null),
+    steerIssue: vi.fn().mockResolvedValue(null),
   };
 }
 
@@ -185,6 +186,39 @@ describe("HTTP routes", () => {
     const body = await res.json();
     expect(body.attempts.length).toBe(1);
     expect(body.current_attempt_id).toBe("a1");
+  });
+
+  it("POST /api/v1/:identifier/steer returns 200 when steer succeeds", async () => {
+    orchestrator.steerIssue.mockResolvedValueOnce({ ok: true });
+    const res = await fetchRoute("/api/v1/MT-42/steer", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "focus on tests" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.message).toBe("steer sent");
+  });
+
+  it("POST /api/v1/:identifier/steer returns 400 with empty body", async () => {
+    const res = await fetchRoute("/api/v1/MT-42/steer", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /api/v1/:identifier/steer returns 404 for unknown issue", async () => {
+    const res = await fetchRoute("/api/v1/UNKNOWN/steer", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "focus on tests" }),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe("not_found");
   });
 
   it("API 404 path returns JSON error", async () => {


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/:issue_identifier/steer` endpoint that lets operators inject mid-turn guidance into running agent sessions
- Plumbs `steerTurn` from `DockerSession` (JSON-RPC `turn/steer`) through `onSteerReady` callback to `RunningEntry` to `Orchestrator.steerIssue` to the HTTP route
- Request validation via Zod `steerSchema` (requires non-empty `message` string)

## Files changed
- `src/http/request-schemas.ts` -- new `steerSchema`
- `src/http/routes.ts` -- new steer route in `registerIssueRoutes`
- `src/orchestrator/port.ts` -- `steerIssue` on `OrchestratorPort`
- `src/orchestrator/orchestrator.ts` -- `steerIssue` implementation
- `src/orchestrator/runtime-types.ts` -- optional `steerTurn` on `RunningEntry`
- `src/orchestrator/worker-launcher.ts` -- wire `onSteerReady` callback
- `src/dispatch/types.ts` -- `onSteerReady` on `RunAttemptDispatcher` input
- `src/agent-runner/index.ts` -- call `onSteerReady` after session creation
- `src/agent-runner/docker-session.ts` -- `steerTurn` on `DockerSession`
- `tests/http/routes.test.ts` -- 3 new tests (200, 400, 404)

## Test plan
- [x] `POST /api/v1/MT-42/steer` with valid message returns 200 `{ ok: true }`
- [x] `POST /api/v1/MT-42/steer` with empty body returns 400
- [x] `POST /api/v1/UNKNOWN/steer` returns 404
- [x] Build passes (`pnpm run build`)
- [x] Lint clean (`pnpm run lint` -- 0 errors)
- [x] Format clean (`pnpm run format:check`)
- [x] All 20 route tests pass
- [x] Knip clean (`pnpm run knip`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
