### PR TITLE
feat(frontend): wire up 6 ignored SSE event types

### DIFF
--- a/frontend/src/state/event-source.ts
+++ b/frontend/src/state/event-source.ts
@@ -13,7 +13,17 @@ const RECONNECT_DELAY_MS = 5_000;
 const CONNECTED_POLL_MS = 30_000;
 const DISCONNECTED_POLL_MS = 5_000;
 
-const LIFECYCLE_EVENTS = new Set(["issue.started", "issue.completed", "issue.stalled"]);
+const LIFECYCLE_EVENTS = new Set(["issue.started", "issue.completed", "issue.stalled", "issue.queued"]);
+
+/** Maps backend event types to their corresponding CustomEvent names for simple dispatch. */
+const EVENT_DISPATCH_MAP = new Map<string, string>([
+  ["agent.event", "symphony:agent-event"],
+  ["worker.failed", "symphony:worker-failed"],
+  ["model.updated", "symphony:model-updated"],
+  ["workspace.event", "symphony:workspace-event"],
+  ["poll.complete", "symphony:poll-complete"],
+  ["system.error", "symphony:system-error"],
+]);
 
 let source: EventSource | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -43,8 +53,9 @@ function openConnection(): void {
         );
       }
     }
-    if (data.type === "agent.event") {
-      window.dispatchEvent(new CustomEvent("symphony:agent-event", { detail: data.payload }));
+    const customEventName = EVENT_DISPATCH_MAP.get(data.type);
+    if (customEventName) {
+      window.dispatchEvent(new CustomEvent(customEventName, { detail: data.payload }));
     }
   };
 
@@ -99,4 +110,33 @@ export function subscribeIssueLifecycle(identifier: string, handler: () => void)
   };
   window.addEventListener("symphony:issue-lifecycle", listener);
   return () => window.removeEventListener("symphony:issue-lifecycle", listener);
+}
+
+/** Subscribe to a CustomEvent by name, forwarding the detail to the handler. */
+function subscribeEvent(eventName: string, handler: (payload: unknown) => void): () => void {
+  const listener = (e: Event) => {
+    handler((e as CustomEvent).detail);
+  };
+  window.addEventListener(eventName, listener);
+  return () => window.removeEventListener(eventName, listener);
+}
+
+export function subscribeWorkerFailed(handler: (payload: unknown) => void): () => void {
+  return subscribeEvent("symphony:worker-failed", handler);
+}
+
+export function subscribeModelUpdated(handler: (payload: unknown) => void): () => void {
+  return subscribeEvent("symphony:model-updated", handler);
+}
+
+export function subscribeWorkspaceEvent(handler: (payload: unknown) => void): () => void {
+  return subscribeEvent("symphony:workspace-event", handler);
+}
+
+export function subscribePollComplete(handler: () => void): () => void {
+  return subscribeEvent("symphony:poll-complete", handler as (payload: unknown) => void);
+}
+
+export function subscribeSystemError(handler: (payload: unknown) => void): () => void {
+  return subscribeEvent("symphony:system-error", handler);
 }

--- a/tests/frontend/event-source.test.ts
+++ b/tests/frontend/event-source.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { subscribeIssueEvents, type AgentEventPayload } from "../../frontend/src/state/event-source";
+import {
+  subscribeIssueEvents,
+  subscribeWorkerFailed,
+  subscribeModelUpdated,
+  subscribeWorkspaceEvent,
+  subscribePollComplete,
+  subscribeSystemError,
+  type AgentEventPayload,
+} from "../../frontend/src/state/event-source";
 
 // Provide a minimal window stub so subscribeIssueEvents can run in Node.
 const fakeTarget = new EventTarget();
@@ -72,5 +80,77 @@ describe("subscribeIssueEvents", () => {
     expect(handler).toHaveBeenCalledOnce();
     expect(handler2).toHaveBeenCalledOnce();
     unsub2();
+  });
+});
+
+describe("subscribeWorkerFailed", () => {
+  it("receives the payload and unsubscribes cleanly", () => {
+    const handler = vi.fn();
+    const unsub = subscribeWorkerFailed(handler);
+    const payload = { issueId: "id-1", identifier: "ENG-1", error: "timeout" };
+    fakeTarget.dispatchEvent(new CustomEvent("symphony:worker-failed", { detail: payload }));
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(payload);
+    unsub();
+    fakeTarget.dispatchEvent(new CustomEvent("symphony:worker-failed", { detail: payload }));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+});
+
+describe("subscribeModelUpdated", () => {
+  it("receives the payload and unsubscribes cleanly", () => {
+    const handler = vi.fn();
+    const unsub = subscribeModelUpdated(handler);
+    const payload = { identifier: "ENG-1", model: "gpt-4o", source: "override" };
+    fakeTarget.dispatchEvent(new CustomEvent("symphony:model-updated", { detail: payload }));
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(payload);
+    unsub();
+    fakeTarget.dispatchEvent(new CustomEvent("symphony:model-updated", { detail: payload }));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+});
+
+describe("subscribeWorkspaceEvent", () => {
+  it("receives the payload and unsubscribes cleanly", () => {
+    const handler = vi.fn();
+    const unsub = subscribeWorkspaceEvent(handler);
+    const payload = { issueId: "id-1", identifier: "ENG-1", status: "ready" };
+    fakeTarget.dispatchEvent(new CustomEvent("symphony:workspace-event", { detail: payload }));
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(payload);
+    unsub();
+    fakeTarget.dispatchEvent(new CustomEvent("symphony:workspace-event", { detail: payload }));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+});
+
+describe("subscribePollComplete", () => {
+  it("calls the handler and unsubscribes cleanly", () => {
+    const handler = vi.fn();
+    const unsub = subscribePollComplete(handler);
+    fakeTarget.dispatchEvent(
+      new CustomEvent("symphony:poll-complete", { detail: { timestamp: "now", issueCount: 3 } }),
+    );
+    expect(handler).toHaveBeenCalledOnce();
+    unsub();
+    fakeTarget.dispatchEvent(
+      new CustomEvent("symphony:poll-complete", { detail: { timestamp: "now", issueCount: 3 } }),
+    );
+    expect(handler).toHaveBeenCalledOnce();
+  });
+});
+
+describe("subscribeSystemError", () => {
+  it("receives the payload and unsubscribes cleanly", () => {
+    const handler = vi.fn();
+    const unsub = subscribeSystemError(handler);
+    const payload = { message: "connection lost", context: { code: 500 } };
+    fakeTarget.dispatchEvent(new CustomEvent("symphony:system-error", { detail: payload }));
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(payload);
+    unsub();
+    fakeTarget.dispatchEvent(new CustomEvent("symphony:system-error", { detail: payload }));
+    expect(handler).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary
- Added `issue.queued` to `LIFECYCLE_EVENTS` so queued issues trigger a UI poll refresh
- Wired up 5 previously dropped SSE events (`worker.failed`, `model.updated`, `workspace.event`, `poll.complete`, `system.error`) via a data-driven `EVENT_DISPATCH_MAP` that replaces individual `if` chains with a single map lookup
- Added a `subscribeEvent` factory to eliminate copy-paste across 5 new subscribe helpers (`subscribeWorkerFailed`, `subscribeModelUpdated`, `subscribeWorkspaceEvent`, `subscribePollComplete`, `subscribeSystemError`)
- Added tests for all 5 new subscribe helpers covering payload forwarding and unsubscribe behavior

## Test plan
- [x] Build passes (`pnpm run build`)
- [x] Lint passes (`pnpm run lint`)
- [x] Format passes (`pnpm run format:check`)
- [x] All new subscribe helper tests pass
- [x] Pre-existing tests unaffected (1795 passed, 1 pre-existing flake in agent-runner)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
