### PR TITLE
feat(frontend): SSE view subscriptions for observability and workspaces

### DIFF
--- a/frontend/src/views/observability-view.ts
+++ b/frontend/src/views/observability-view.ts
@@ -4,6 +4,7 @@ import { createPageHeader } from "../components/page-header";
 import { APP_STATE_HEARTBEAT_EVENT, APP_STATE_UPDATE_EVENT, store } from "../state/store";
 import type { AppState } from "../state/store";
 import { toast } from "../ui/toast";
+import { flashDiff } from "../utils/diff";
 import { registerPageCleanup } from "../utils/page";
 
 import { handleObservabilityKeyboard } from "./observability-keyboard";
@@ -121,14 +122,20 @@ export function createObservabilityPage(): HTMLElement {
     });
   };
 
+  const onPollComplete = (): void => {
+    void loadMetrics().then(() => flashDiff(body));
+  };
+
   window.addEventListener(APP_STATE_UPDATE_EVENT, onState);
   window.addEventListener(APP_STATE_HEARTBEAT_EVENT, onState);
+  window.addEventListener("symphony:poll-complete", onPollComplete);
   window.addEventListener("keydown", onKey);
   sync(store.getState());
   void loadMetrics();
   registerPageCleanup(page, () => {
     window.removeEventListener(APP_STATE_UPDATE_EVENT, onState);
     window.removeEventListener(APP_STATE_HEARTBEAT_EVENT, onState);
+    window.removeEventListener("symphony:poll-complete", onPollComplete);
     window.removeEventListener("keydown", onKey);
   });
   return page;

--- a/frontend/src/views/workspaces-view.ts
+++ b/frontend/src/views/workspaces-view.ts
@@ -5,6 +5,7 @@ import { router } from "../router.js";
 import { statusChip } from "../ui/status-chip.js";
 import { skeletonLine } from "../ui/skeleton.js";
 import type { WorkspaceInventoryEntry, WorkspaceInventoryResponse } from "../types.js";
+import { flashDiff } from "../utils/diff.js";
 import { el } from "../utils/dom.js";
 import { registerPageCleanup } from "../utils/page.js";
 import { formatBytes, formatRelativeTime } from "../utils/format.js";
@@ -224,8 +225,15 @@ export function createWorkspacesPage(): HTMLElement {
   const handler = (): void => {
     if (currentData) void fetchAndRender();
   };
+  const onWorkspaceEvent = (): void => {
+    void fetchAndRender().then(() => flashDiff(body));
+  };
   window.addEventListener("state:update", handler);
-  registerPageCleanup(page, () => window.removeEventListener("state:update", handler));
+  window.addEventListener("symphony:workspace-event", onWorkspaceEvent);
+  registerPageCleanup(page, () => {
+    window.removeEventListener("state:update", handler);
+    window.removeEventListener("symphony:workspace-event", onWorkspaceEvent);
+  });
 
   return page;
 }


### PR DESCRIPTION
## Summary

- Wire `symphony:poll-complete` CustomEvent listener into the observability view, triggering `loadMetrics()` for reactive data refresh when the backend SSE stream delivers poll completion events
- Wire `symphony:workspace-event` CustomEvent listener into the workspaces view, triggering `fetchAndRender()` for reactive updates on workspace state changes
- Apply `flashDiff` visual feedback on the content body after each SSE-triggered refresh for subtle delight
- Both listeners are properly cleaned up via `registerPageCleanup` on page teardown

**Independently mergeable**: These listeners wait for Unit 2 (SSE dispatcher) to dispatch the events. Until that code lands, they simply never fire and cause no errors.

## Test plan

- [x] `pnpm run build` passes (TypeScript compilation + Vite frontend build)
- [x] `pnpm run lint` passes (0 errors, only pre-existing warnings in unrelated files)
- [x] `pnpm run format:check` passes
- [x] `pnpm test` passes (1791 tests, 0 failures)
- [x] `pnpm exec playwright test --project=smoke` — 91/96 pass (5 pre-existing failures in model override and sidebar contextual nav tests, unrelated to this change)
- [x] Pre-push hooks pass (build, lint, format, test, knip, jscpd, semgrep)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
