### PR TITLE
feat(frontend): add steer issue API client and UI section

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -8,6 +8,7 @@ import type {
   RuntimeInfo,
   RuntimeSnapshot,
   SetupStatus,
+  SteerIssueResponse,
   WorkspaceInventoryResponse,
 } from "./types";
 
@@ -73,6 +74,10 @@ export const api = {
   postAbortIssue: (id: string) => {
     if (!id) return Promise.reject(new Error("issue id is required"));
     return send<AbortIssueResponse>("POST", `/api/v1/${encodeURIComponent(id)}/abort`);
+  },
+  postSteerIssue: (id: string, message: string) => {
+    if (!id) return Promise.reject(new Error("issue id is required"));
+    return post<SteerIssueResponse>(`/api/v1/${encodeURIComponent(id)}/steer`, { message });
   },
   getAttempts: (id: string) => {
     if (!id) return Promise.resolve({ attempts: [] as AttemptSummary[], current_attempt_id: null });

--- a/frontend/src/components/issue-inspector-sections.ts
+++ b/frontend/src/components/issue-inspector-sections.ts
@@ -5,7 +5,7 @@ import { router } from "../router";
 import { statusChip } from "../ui/status-chip";
 import { toast } from "../ui/toast";
 import { createAttemptsTable } from "./attempts-table";
-import { createButton, createField, createSelectControl } from "./forms.js";
+import { createButton, createField, createSelectControl, createTextareaControl } from "./forms.js";
 import { createEventRow } from "./event-row";
 import { createEmptyState } from "./empty-state";
 import {
@@ -193,5 +193,59 @@ export function buildAttemptsSection(detail: IssueDetail): HTMLElement {
   section.className = "issue-section mc-panel expand-in";
   section.append(Object.assign(document.createElement("h2"), { textContent: "Attempts" }));
   section.append(createAttemptsTable(detail.attempts, (attemptId) => router.navigate(`/attempts/${attemptId}`)));
+  return section;
+}
+
+export function buildSteerSection(detail: IssueDetail): HTMLElement | null {
+  if (detail.status !== "running") {
+    return null;
+  }
+
+  const section = document.createElement("section");
+  section.className = "issue-section mc-panel expand-in";
+  section.append(Object.assign(document.createElement("h2"), { textContent: "Steer agent" }));
+
+  const description = document.createElement("p");
+  description.className = "text-secondary";
+  description.textContent = "Send mid-turn guidance to the running agent.";
+  section.append(description);
+
+  const form = document.createElement("form");
+  form.className = "issue-steer-form";
+
+  const textarea = createTextareaControl({
+    placeholder: "Enter guidance for the agent...",
+    required: true,
+    rows: 3,
+  });
+
+  const submitBtn = createButton("Send", "primary", "submit");
+
+  form.append(
+    createField({ label: "Guidance", hint: "The agent will receive this message during its current turn." }, textarea),
+    submitBtn,
+  );
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const message = textarea.value.trim();
+    if (!message) return;
+    submitBtn.disabled = true;
+    try {
+      const result = await api.postSteerIssue(detail.identifier, message);
+      if (result.ok) {
+        toast("Guidance sent to agent.", "success");
+        textarea.value = "";
+      } else {
+        toast(result.message || "Failed to send guidance.", "error");
+      }
+    } catch (error) {
+      toast(error instanceof Error ? error.message : "Failed to send guidance.", "error");
+    } finally {
+      submitBtn.disabled = false;
+    }
+  });
+
+  section.append(form);
   return section;
 }

--- a/frontend/src/components/issue-inspector.ts
+++ b/frontend/src/components/issue-inspector.ts
@@ -14,6 +14,7 @@ import {
   buildAttemptsSection,
   buildDescriptionSection,
   buildModelSection,
+  buildSteerSection,
   buildWorkspaceSection,
 } from "./issue-inspector-sections";
 import { createIssueAbortAction } from "./issue-inspector-abort";
@@ -177,6 +178,7 @@ export function createIssueInspector(options: IssueInspectorOptions): {
     const sections = [
       buildDescriptionSection(detail),
       buildRetrySection(detail),
+      buildSteerSection(detail),
       liveLogSection,
       buildActivitySection(detail),
       buildWorkspaceSection(detail),

--- a/frontend/src/styles/issue.css
+++ b/frontend/src/styles/issue.css
@@ -111,6 +111,12 @@
   text-align: left;
 }
 
+.issue-steer-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
 @media (max-width: 900px) {
   .issue-retry-strip,
   .issue-summary-strip,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -76,6 +76,11 @@ export interface AbortIssueResponse {
   requested_at: string;
 }
 
+export interface SteerIssueResponse {
+  ok: boolean;
+  message: string;
+}
+
 export interface AttemptSummary {
   attemptId: string;
   attemptNumber: number | null;

--- a/tests/e2e/mocks/api-mock.ts
+++ b/tests/e2e/mocks/api-mock.ts
@@ -188,6 +188,9 @@ export async function installApiMock(page: Page, overrides: ApiMockOverrides = {
     }),
   );
 
+  // Steer
+  await page.route(/\/api\/v1\/[^/]+\/steer$/, (route) => json(route, { ok: true, message: "steer sent" }));
+
   // Model override
   await page.route(/\/api\/v1\/[^/]+\/model$/, (route) => json(route, {}, 200));
 


### PR DESCRIPTION
## Summary
- Add `postSteerIssue(id, message)` to the frontend API client, wiring up the existing `POST /api/v1/:id/steer` backend endpoint
- Add `buildSteerSection()` to the issue inspector that renders a textarea + submit form for sending mid-turn guidance to a running agent
- Section only appears when the issue status is `"running"`, consistent with the live log visibility guard
- Add E2E mock route for `/steer` so Playwright smoke tests pass with the new API call

## Test plan
- [x] `pnpm run build` passes (TypeScript compilation + Vite frontend build)
- [x] `pnpm run lint` passes (0 errors, only pre-existing warnings)
- [x] `pnpm run format:check` passes
- [x] `pnpm test` passes (1791 tests, 157 test files)
- [x] `pnpm exec playwright test --project=smoke` passes (95/96; 1 pre-existing failure in model form selector unrelated to this change)
- [x] Pre-push hook (build + lint + format + test + knip) passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
