### PR TITLE
feat(frontend): add API docs link to header and command palette

### DIFF
--- a/frontend/src/ui/command-palette-data.ts
+++ b/frontend/src/ui/command-palette-data.ts
@@ -99,6 +99,16 @@ function buildQuickActionEntries(options: CreateBasePaletteEntriesOptions): Pale
       keywords: ["shortcuts", "help", "keyboard", "discover"],
       run: () => openShortcutHelp(),
     },
+    {
+      id: "action:api-docs",
+      name: "API documentation",
+      description: "Open the Swagger UI API reference",
+      meta: "Action",
+      group: "Quick actions",
+      icon: "issueDetail",
+      keywords: ["api", "docs", "swagger", "openapi", "reference"],
+      run: () => window.open("/api/docs", "_blank", "noopener"),
+    },
   ];
 
   const runsPath = options.resolveRunHistoryPath?.();

--- a/frontend/src/ui/header.ts
+++ b/frontend/src/ui/header.ts
@@ -139,12 +139,21 @@ export function initHeader(headerEl: HTMLElement): void {
     }, 500);
   });
 
+  const apiDocsButton = createIconButton({
+    iconName: "issueDetail",
+    label: "API documentation",
+    className: "header-action-btn",
+  });
+  apiDocsButton.addEventListener("click", () => {
+    window.open("/api/docs", "_blank", "noopener");
+  });
+
   themeButton.addEventListener("click", () => {
     const next = toggleTheme();
     toast(`Theme: ${next}`, "info");
   });
 
-  actions.append(refreshButton, themeButton);
+  actions.append(refreshButton, apiDocsButton, themeButton);
   headerEl.append(brand, createZoneSeparator(), command, createZoneSeparator(), actions);
   syncHeaderNavButton(headerEl, navButton, {
     mobile: window.matchMedia(MOBILE_BREAKPOINT).matches,


### PR DESCRIPTION
## Summary
- Adds an API documentation icon button to the header action bar (between refresh and theme toggle) that opens `/api/docs` in a new tab
- Adds an "API documentation" entry to the command palette Quick Actions group, searchable by keywords: api, docs, swagger, openapi, reference
- Resolves frontend gap where operators could only discover the Swagger UI by manually typing the URL

## Test plan
- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes (0 errors, only pre-existing warnings)
- [x] `pnpm run format:check` passes
- [x] `pnpm test` passes (1791 passed, 1 skipped)
- [x] `pnpm exec playwright test --project=smoke` passes (95/96; 1 pre-existing failure in model override tests, confirmed on base branch)
- [ ] Verify header button renders between refresh and theme buttons
- [ ] Verify clicking header button opens `/api/docs` in new tab
- [ ] Verify command palette entry appears when searching "api" or "swagger"
- [ ] Verify command palette entry opens `/api/docs` in new tab
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
