### PR TITLE
fix(frontend): replace misleading observability fallback strings

### DIFF
--- a/frontend/src/views/observability-anomalies.ts
+++ b/frontend/src/views/observability-anomalies.ts
@@ -17,45 +17,57 @@ export function buildAnomalySummary(
   metrics: ParsedPrometheusMetrics,
   staleCount: number,
 ): AnomalySummary {
-  const last = trends[trends.length - 1];
-  const previous = trends[trends.length - 2];
+  const spikes = detectSpikes(trends);
+  const failures = detectFailures(snapshot, metrics);
+  const stale = detectStaleness(snapshot, staleCount);
+  const instrumentation = buildInstrumentationWarnings(metrics);
+  return { spikes, failures, stale, instrumentation };
+}
+
+function detectSpikes(trends: ObservabilityTrendPoint[]): string[] {
+  const last = trends.at(-1);
+  const previous = trends.at(-2);
   const tokenDelta = last && previous ? last.totalTokens - previous.totalTokens : 0;
   const queueDelta = last && previous ? last.queueDepth - previous.queueDepth : 0;
-  const spikes = [
+  return [
     tokenDelta > averageDelta(trends.map((point) => point.totalTokens)) * 1.8 && tokenDelta > 500
       ? `Token burn jumped by ${formatCompactNumber(tokenDelta)} since the last snapshot.`
       : "",
     queueDelta >= 3 ? `Queue pressure increased by ${queueDelta} issues in the latest snapshot.` : "",
   ].filter(Boolean);
+}
+
+function detectFailures(snapshot: RuntimeSnapshot | null, metrics: ParsedPrometheusMetrics): string[] {
   const failureTotal =
     sumMetric(metrics, "symphony_agent_runs_total", { outcome: "failed" }) ??
     sumMetric(metrics, "symphony_agent_runs_total", { status: "failed" }) ??
     0;
   const retrySignals =
     snapshot?.recent_events.filter((event) => /retry|failed|timed out|stalled/i.test(event.message)).length ?? 0;
-  const failures =
-    failureTotal >= 3 || retrySignals >= 3
-      ? [
-          `${formatCompactNumber(failureTotal)} backend failures recorded.`,
-          retrySignals ? `${retrySignals} recent event log entries mention retry or failure pressure.` : "",
-        ].filter(Boolean)
-      : [];
+  if (failureTotal < 3 && retrySignals < 3) {
+    return [];
+  }
+  return [
+    `${formatCompactNumber(failureTotal)} backend failures recorded.`,
+    retrySignals ? `${retrySignals} recent event log entries mention retry or failure pressure.` : "",
+  ].filter(Boolean);
+}
+
+function detectStaleness(snapshot: RuntimeSnapshot | null, staleCount: number): string[] {
   const staleAgeMs = snapshot ? Date.now() - new Date(snapshot.generated_at).getTime() : 0;
-  const stale =
-    staleCount >= 3 || staleAgeMs > 45_000
-      ? [
-          staleCount >= 3 ? `Frontend polling missed ${staleCount} consecutive updates.` : "",
-          staleAgeMs > 45_000 ? `Latest backend snapshot is ${Math.round(staleAgeMs / 1000)}s old.` : "",
-        ].filter(Boolean)
-      : [];
-  const instrumentation = buildInstrumentationWarnings(metrics);
-  return { spikes, failures, stale, instrumentation };
+  if (staleCount < 3 && staleAgeMs <= 45_000) {
+    return [];
+  }
+  return [
+    staleCount >= 3 ? `Frontend polling missed ${staleCount} consecutive updates.` : "",
+    staleAgeMs > 45_000 ? `Latest backend snapshot is ${Math.round(staleAgeMs / 1000)}s old.` : "",
+  ].filter(Boolean);
 }
 
 function buildInstrumentationWarnings(metrics: ParsedPrometheusMetrics): string[] {
   const missing = getMissingFamilies(metrics);
   if (missing.length) {
-    return missing.map((name) => `${humanizeMetric(name)} instrumentation not yet present.`);
+    return missing.map((name) => `${humanizeMetric(name)} not yet observed.`);
   }
   const summary = summarizeMetrics(metrics);
   if (summary.includes("sparse") || summary.includes("zeroed")) {

--- a/frontend/src/views/observability-metrics.ts
+++ b/frontend/src/views/observability-metrics.ts
@@ -74,7 +74,7 @@ export function meanHistogramMs(metrics: ParsedPrometheusMetrics, baseName: stri
 
 export function summarizeMetrics(metrics: ParsedPrometheusMetrics): string {
   if (!metrics.samples.length) {
-    return "Instrumentation not yet present";
+    return "No metric samples received yet";
   }
   const total = metrics.samples.length;
   const nonZero = metrics.samples.filter((sample) => sample.value !== 0).length;
@@ -100,7 +100,7 @@ export function buildHttpHealthSummary(metrics: ParsedPrometheusMetrics): string
     .reduce((count, sample) => count + sample.value, 0);
   const latency = meanHistogramMs(metrics, "symphony_http_request_duration_seconds");
   if (total === null) {
-    return "Instrumentation not yet present";
+    return "No HTTP traffic recorded yet";
   }
   return `${formatCompactNumber(total)} requests · ${formatCompactNumber(errors)} 5xx · ${formatLatency(latency)} avg`;
 }
@@ -108,15 +108,16 @@ export function buildHttpHealthSummary(metrics: ParsedPrometheusMetrics): string
 export function buildPollSummary(metrics: ParsedPrometheusMetrics, trends: ObservabilityTrendPoint[]): string {
   const polls = sumMetric(metrics, "symphony_orchestrator_polls_total");
   const cadence = describeCadence(trends);
+  const cadenceSuffix = cadence ? ` · ${cadence}` : "";
   if (polls === null) {
-    return `Instrumentation not yet present${cadence ? ` · ${cadence}` : ""}`;
+    return `No poll cycles recorded yet${cadenceSuffix}`;
   }
-  return `${formatCompactNumber(polls)} poll cycles${cadence ? ` · ${cadence}` : ""}`;
+  return `${formatCompactNumber(polls)} poll cycles${cadenceSuffix}`;
 }
 
 export function buildRateLimitSummary(rateLimits: RateLimits | null): string {
   if (!rateLimits || typeof rateLimits !== "object") {
-    return "Instrumentation not yet present";
+    return "Rate-limit data not available";
   }
   const record = rateLimits as Record<string, unknown>;
   const remaining = Number(record.remaining ?? 0);
@@ -124,7 +125,7 @@ export function buildRateLimitSummary(rateLimits: RateLimits | null): string {
   const resetsAt = String(record.reset_at ?? record.resets_at ?? "");
   const resetSuffix = resetsAt ? ` · resets ${formatRelativeTime(resetsAt)}` : "";
   if (!limit) {
-    return "Instrumentation not yet present";
+    return "Rate-limit data not available";
   }
   return `${formatCompactNumber(remaining)} of ${formatCompactNumber(limit)} remaining${resetSuffix}`;
 }
@@ -133,14 +134,14 @@ export function formatCpuMemory(metrics: ParsedPrometheusMetrics): string {
   const cpu = sumMetric(metrics, "symphony_container_cpu_percent");
   const memory = sumMetric(metrics, "symphony_container_memory_percent");
   if (cpu === null && memory === null) {
-    return "Instrumentation not yet present";
+    return "No active containers";
   }
   return `CPU ${formatPercent(cpu)} · Memory ${formatPercent(memory)}`;
 }
 
 export function formatHeadroom(rateLimits: RateLimits | null): string {
   const headroom = formatRateLimitHeadroom(rateLimits);
-  return headroom === "N/A" ? "Instrumentation not yet present" : headroom;
+  return headroom === "N/A" ? "Rate-limit data not available" : headroom;
 }
 
 export function formatPollAge(snapshot: RuntimeSnapshot | null): string {
@@ -188,7 +189,7 @@ function parseLabels(input: string): Record<string, string> {
   }
   return Object.fromEntries(
     input
-      .split(/,(?=[a-zA-Z_][a-zA-Z0-9_]*=)/)
+      .split(/,(?=[a-zA-Z_]\w*=)/)
       .map((part) => part.trim())
       .filter(Boolean)
       .map((pair) => {
@@ -220,7 +221,7 @@ function formatPercent(value: number | null): string {
 
 export function formatLatency(valueMs: number | null): string {
   if (valueMs === null || Number.isNaN(valueMs)) {
-    return "Instrumentation not yet present";
+    return "No latency data yet";
   }
   if (valueMs >= 1000) {
     return `${(valueMs / 1000).toFixed(2)}s`;

--- a/frontend/src/views/observability-raw-drawer.ts
+++ b/frontend/src/views/observability-raw-drawer.ts
@@ -22,7 +22,7 @@ export function createRawMetricsDrawer(onClose: () => void): RawMetricsDrawerCon
     root,
     render: (rawMetrics, open) => {
       root.hidden = !open;
-      body.textContent = rawMetrics.trim() || "Instrumentation not yet present.";
+      body.textContent = rawMetrics.trim() || "No metrics endpoint response yet.";
     },
   };
 }


### PR DESCRIPTION
## Summary
- Replaced all "Instrumentation not yet present" fallback strings across the observability UI with contextually accurate messages that tell operators WHY data is missing (e.g., "No active containers", "No HTTP traffic recorded yet", "Rate-limit data not available")
- Updated `observability-anomalies.ts` warning copy from "instrumentation not yet present" to "not yet observed"
- Updated `observability-raw-drawer.ts` empty-state copy to "No metrics endpoint response yet"
- Fixed pre-existing SonarCloud lint issues in touched files: nested template literals, verbose regex character class, and cognitive complexity (extracted `detectSpikes`, `detectFailures`, `detectStaleness` helpers)

## Test plan
- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run format:check` passes
- [x] `pnpm test` passes (1790/1791 pass; 1 pre-existing flaky timeout in agent-runner unrelated to this change)
- [x] Pre-push hook gate passes (build + lint + format + test + knip + semgrep)
- [x] No remaining instances of "Instrumentation not yet present" in the codebase
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
