### PR TITLE
style(frontend): layout, animation & performance polish

### DIFF
--- a/frontend/src/styles/animations.css
+++ b/frontend/src/styles/animations.css
@@ -1,3 +1,46 @@
+/* ============================================
+   ANIMATIONS
+   Entrance animations, loading states, and
+   reduced-motion overrides.
+
+   Performance notes:
+   - All entrance keyframes animate only `opacity`
+     and `transform` (GPU-composited properties).
+   - Infinite animations (skeleton, status pulse)
+     use `opacity` only — no layout or paint.
+   - `will-change` is scoped to active animation
+     states, not applied globally.
+   ============================================ */
+
+/* ── Shared entrance keyframe ────────────────────────── */
+/* Parameterized via --enter-y for distance variants.
+   Uses only opacity + transform (composited).           */
+
+@keyframes enterUp {
+  from {
+    opacity: 0;
+    transform: translateY(var(--enter-y, 8px));
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Scale variant — for panels/cards that expand in */
+@keyframes enterUpScale {
+  from {
+    opacity: 0;
+    transform: translateY(var(--enter-y, 8px)) scale(0.995);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ── Transition utility ──────────────────────────────── */
+
 .transition-base {
   transition:
     color var(--motion-fast) var(--ease-out-quart),
@@ -7,84 +50,39 @@
     transform var(--motion-medium) var(--ease-out-quint);
 }
 
+/* ── Entrance animation classes ──────────────────────── */
+
 .fade-in {
-  animation: fadeIn var(--motion-medium) var(--ease-out-quart);
+  --enter-y: 4px;
+  animation: enterUp var(--motion-medium) var(--ease-out-quart);
 }
 
 .page-enter {
-  animation: pageEnter var(--motion-slow) var(--ease-out-expo);
+  --enter-y: 8px;
+  animation: enterUp var(--motion-slow) var(--ease-out-expo);
 }
 
 .stagger-item {
   --stagger-index: 0;
-  animation: riseIn var(--motion-medium) var(--ease-out-quart) both;
+  --enter-y: 10px;
+  animation: enterUp var(--motion-medium) var(--ease-out-quart) both;
   animation-delay: calc(var(--stagger-index) * 55ms);
 }
 
 .timeline-enter {
   --stagger-index: 0;
-  animation: timelineIn var(--motion-fast) var(--ease-out-quart) both;
+  --enter-y: 6px;
+  animation: enterUp var(--motion-fast) var(--ease-out-quart) both;
   animation-delay: calc(var(--stagger-index) * 24ms);
 }
 
 .expand-in {
-  animation: expandIn var(--motion-medium) var(--ease-out-quart);
+  --enter-y: 8px;
+  animation: enterUpScale var(--motion-medium) var(--ease-out-quart);
 }
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(4px);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
-
-@keyframes pageEnter {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
-
-@keyframes riseIn {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
-
-@keyframes timelineIn {
-  from {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
-
-@keyframes expandIn {
-  from {
-    opacity: 0;
-    transform: translateY(8px) scale(0.995);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
+/* ── Loading states ──────────────────────────────────── */
+/* Skeleton and status pulse animate opacity only (composited). */
 
 .skeleton {
   background: var(--bg-muted);
@@ -115,11 +113,17 @@
   }
 }
 
+/* ── Reduced motion ──────────────────────────────────── */
+/* Respects prefers-reduced-motion: animations resolve
+   instantly, transitions collapse to near-zero duration,
+   and transforms are neutralized.                        */
+
 @media (prefers-reduced-motion: reduce) {
   .transition-base {
     transition-duration: 0.01ms;
   }
 
+  /* Entrance animations — instant resolve */
   .fade-in,
   .page-enter,
   .stagger-item,
@@ -136,16 +140,19 @@
     transform: none !important;
   }
 
+  /* Shell sidebar collapse */
   .sidebar-group-items {
     transition-duration: 0.01ms;
   }
 
+  /* Focus ring animations */
   .mc-list-item:focus-visible,
   .mc-rail-item:focus-visible,
   .mc-button:focus-visible {
     animation-duration: 0.01ms !important;
   }
 
+  /* Kanban board */
   .kanban-column.stagger-item,
   .kanban-card.stagger-item {
     animation-duration: 0.01ms;
@@ -159,14 +166,12 @@
     animation-duration: 0.01ms;
   }
 
+  /* Queue page kanban — preserve dragging feedback */
   .queue-page .kanban-card {
     transition: none;
   }
 
-  .queue-page .kanban-card:hover {
-    transform: none;
-  }
-
+  .queue-page .kanban-card:hover,
   .queue-page .kanban-card:active {
     transform: none;
   }
@@ -181,6 +186,7 @@
     transform: scale(0.96);
   }
 
+  /* Interactive components — near-instant transitions */
   .mc-button,
   .mc-input,
   .mc-select,
@@ -204,19 +210,29 @@
     transition-duration: 0.01ms;
   }
 
+  /* Overlays */
   .toast,
   .drawer {
     animation-duration: 0.01ms !important;
   }
 
+  /* Skeleton variants */
   .skeleton-line,
   .skeleton-block {
     animation: none !important;
     opacity: 0.6;
   }
 
+  /* Status pseudo-element pulses */
   .is-status-running::before,
   .is-status-claimed::before {
     animation: none !important;
+  }
+
+  /* Mobile backdrop */
+  .shell-sidebar-backdrop {
+    animation: none !important;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
   }
 }

--- a/frontend/src/styles/shell-responsive.css
+++ b/frontend/src/styles/shell-responsive.css
@@ -78,6 +78,18 @@
     border: none;
     background: color-mix(in srgb, var(--bg-base) 62%, transparent);
     cursor: pointer;
+    -webkit-backdrop-filter: blur(2px);
+    backdrop-filter: blur(2px);
+    animation: backdropFadeIn var(--motion-fast) var(--ease-out-quart) both;
+  }
+
+  @keyframes backdropFadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
   }
 
   .shell-sidebar.is-mobile {
@@ -89,9 +101,8 @@
     transform: translateX(-100%);
     border-right: 1px solid var(--border-stitch);
     box-shadow: var(--shadow-lg);
-    transition:
-      transform 0.22s var(--ease-out-quart),
-      width 0.22s var(--ease-out-quart);
+    will-change: transform;
+    transition: transform var(--motion-medium) var(--ease-out-quart);
   }
 
   .shell-sidebar.is-mobile.is-mobile-open {

--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -14,9 +14,12 @@
   flex-direction: column;
   padding: var(--space-3) 0;
   gap: var(--space-1);
-  transition: width 0.22s var(--ease-out-quart);
+  transition:
+    width var(--motion-medium) var(--ease-out-quart),
+    transform var(--motion-medium) var(--ease-out-quart);
   overflow-y: auto;
   overflow-x: hidden;
+  contain: style;
 }
 
 .shell-sidebar.is-expanded {
@@ -28,7 +31,6 @@
 .sidebar-group {
   display: flex;
   flex-direction: column;
-  gap: 0;
   padding: 0 var(--space-2);
 }
 
@@ -80,7 +82,7 @@
   cursor: pointer;
   user-select: none;
   appearance: none;
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   transition:
     color var(--motion-fast) var(--ease-out-quart),
     background-color var(--motion-fast) var(--ease-out-quart);
@@ -125,9 +127,9 @@
 /* Sidebar group collapse animation */
 .sidebar-group-items {
   display: grid;
-  gap: 0;
   transition: grid-template-rows var(--motion-fast) var(--ease-out-quart);
   grid-template-rows: 1fr;
+  contain: layout style;
 }
 
 .sidebar-group.is-collapsed .sidebar-group-items {
@@ -224,7 +226,7 @@
 .sidebar-item-badge {
   margin-left: auto;
   padding: 2px 7px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   line-height: 1;
   color: var(--color-copper-100);
   background: color-mix(in srgb, var(--color-copper-500) 80%, transparent);
@@ -319,7 +321,7 @@
   min-height: calc(var(--sidebar-width-collapsed) - 14px);
   margin: 0 auto;
   border-left: none;
-  border-radius: 12px;
+  border-radius: var(--radius-sm);
 }
 
 .shell-sidebar:not(.is-expanded) .sidebar-item-badge {
@@ -339,7 +341,7 @@
   content: none;
 }
 
-@media (max-width: 800px) {
+@media (max-width: 760px) {
   .sidebar-item-tooltip {
     display: none;
   }
@@ -395,7 +397,7 @@
   margin: auto auto 0;
   padding: 0;
   border-top: none;
-  border-radius: 12px;
+  border-radius: var(--radius-sm);
 }
 
 .sidebar-collapse-label {
@@ -575,13 +577,13 @@
     position: absolute;
     z-index: 100;
     height: 100%;
+    will-change: transform;
   }
 
   .shell-sidebar:not(.is-expanded) {
-    width: 0;
-    padding: 0;
+    transform: translateX(-100%);
+    pointer-events: none;
     border-right: none;
-    overflow: hidden;
   }
 
   .shell-sidebar:not(.is-expanded) .sidebar-group,
@@ -627,15 +629,15 @@
   }
 }
 
-/* Touch-friendly targets */
+/* Touch-friendly targets — use control height token for consistency */
 @media (pointer: coarse) {
   .sidebar-group-header,
   .sidebar-collapse-toggle {
-    min-height: 44px;
+    min-height: var(--control-height-xl);
   }
 
   .header-action-btn,
   .header-command-trigger {
-    min-height: 44px;
+    min-height: var(--control-height-xl);
   }
 }


### PR DESCRIPTION
## Summary

- Consolidate 5 near-identical entrance keyframes into 2 parameterized keyframes (`enterUp`, `enterUpScale`) using `--enter-y` CSS custom property for distance variants, reducing duplication while preserving all animation behavior
- Replace layout-triggering sidebar hide/show at 900px (`width: 0`) with GPU-composited `transform: translateX(-100%)`, add `will-change: transform` hints on animated elements, and add `contain` declarations to limit reflow scope
- Normalize hardcoded values to design tokens: `border-radius` (12px -> `--radius-sm`), timing (0.22s -> `--motion-medium`), touch targets (44px -> `--control-height-xl`), and breakpoints (800px -> 760px alignment)
- Add backdrop blur and fade-in animation to mobile sidebar overlay, with proper `prefers-reduced-motion` override

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes (0 errors, pre-existing warnings only)
- [x] `pnpm run format:check` passes
- [x] `pnpm test` passes (1791 tests, 0 failures)
- [ ] Visual verification: sidebar expand/collapse animation is smooth
- [ ] Visual verification: mobile drawer slides in/out with backdrop
- [ ] Visual verification: page entrance animations (fade-in, stagger) work as before
- [ ] Visual verification: reduced-motion mode disables all animations
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
