### PR TITLE
feat(frontend): add SSE toast consumers for system event notifications

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -28,6 +28,7 @@ import { initKeyboard } from "./ui/keyboard";
 import { getRouteAnnouncer, initShell } from "./ui/shell";
 import { initSidebar } from "./ui/sidebar";
 import { initTheme } from "./ui/theme";
+import { deduplicatedToast } from "./utils/toast-events.js";
 
 let lastIssueContextId: string | null = null;
 
@@ -171,4 +172,24 @@ api
 window.addEventListener("setup:complete", () => {
   setupComplete = true;
   router.setGuard(() => null);
+});
+
+// ── SSE system event toast notifications ──────────────────────────────
+
+window.addEventListener("symphony:worker-failed", (event) => {
+  const detail = (event as CustomEvent<{ error?: string; identifier?: string }>).detail;
+  const message = detail?.error ?? "A worker process failed";
+  deduplicatedToast(`Worker failed: ${message}`, "error");
+});
+
+window.addEventListener("symphony:system-error", (event) => {
+  const detail = (event as CustomEvent<{ message?: string }>).detail;
+  const message = detail?.message ?? "An unexpected system error occurred";
+  deduplicatedToast(`System error: ${message}`, "error");
+});
+
+window.addEventListener("symphony:model-updated", (event) => {
+  const detail = (event as CustomEvent<{ identifier?: string; model?: string }>).detail;
+  const identifier = detail?.identifier ?? "unknown";
+  deduplicatedToast(`Model updated for ${identifier}`, "info");
 });

--- a/frontend/src/ui/toast.ts
+++ b/frontend/src/ui/toast.ts
@@ -1,6 +1,6 @@
 let container: HTMLElement | null = null;
 
-type ToastType = "success" | "error" | "info" | "warning";
+export type ToastType = "success" | "error" | "info" | "warning";
 
 interface ToastAction {
   label: string;

--- a/frontend/src/utils/toast-events.ts
+++ b/frontend/src/utils/toast-events.ts
@@ -1,0 +1,21 @@
+/**
+ * Deduplicated toast utility for SSE system event notifications.
+ *
+ * Wraps the base `toast()` call with a time-windowed deduplication set
+ * so that identical messages arriving within DEDUP_WINDOW_MS are dropped.
+ * This prevents toast flooding when the backend emits rapid-fire events
+ * (e.g. repeated worker failures for the same issue).
+ */
+
+import { toast } from "../ui/toast.js";
+import type { ToastType } from "../ui/toast.js";
+
+const recentMessages = new Set<string>();
+const DEDUP_WINDOW_MS = 10_000;
+
+export function deduplicatedToast(message: string, type: ToastType): void {
+  if (recentMessages.has(message)) return;
+  recentMessages.add(message);
+  setTimeout(() => recentMessages.delete(message), DEDUP_WINDOW_MS);
+  toast(message, type);
+}


### PR DESCRIPTION
## Summary

- Add deduplicated toast notifications for `worker.failed`, `system.error`, and `model.updated` SSE events
- New utility `frontend/src/utils/toast-events.ts` wraps `toast()` with a 10-second dedup window to prevent flooding from rapid-fire backend events
- Export `ToastType` from `frontend/src/ui/toast.ts` so downstream modules can import the canonical type
- Register three passive `window` listeners in `frontend/src/main.ts` for `symphony:worker-failed`, `symphony:system-error`, and `symphony:model-updated` CustomEvents

The listeners are independently mergeable. They consume CustomEvents that the SSE event-source dispatcher (separate unit) will emit. Until that dispatcher lands, the listeners are inert and cause no errors.

## Test plan

- [x] `pnpm run build` passes (TypeScript compilation + Vite frontend build)
- [x] `pnpm run lint` passes (0 errors, only pre-existing warnings)
- [x] `pnpm run format:check` passes
- [x] `pnpm test` passes (1791 tests, 0 failures)
- [x] `pnpm exec playwright test --project=smoke` passes (3 pre-existing Model Override failures unrelated to this change, confirmed by running against clean branch)
- [x] `pnpm run knip` passes (no dead code introduced)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
