### PR TITLE
feat(frontend): config-aware notifications empty state

### DIFF
--- a/frontend/src/views/notifications-view.ts
+++ b/frontend/src/views/notifications-view.ts
@@ -1,6 +1,47 @@
-import { createEmptyState } from "../components/empty-state";
-import { createPageHeader } from "../components/page-header";
-import { router } from "../router";
+import { api } from "../api.js";
+import { createEmptyState } from "../components/empty-state.js";
+import { createPageHeader } from "../components/page-header.js";
+import { skeletonBlock } from "../ui/skeleton.js";
+import { router } from "../router.js";
+import { getValueAtPath } from "./settings-paths.js";
+
+function isSlackConfigured(config: Record<string, unknown>): boolean {
+  const webhookUrl = getValueAtPath(config, "notifications.slack.webhook_url");
+  const verbosity = getValueAtPath(config, "notifications.slack.verbosity");
+  const hasWebhook = typeof webhookUrl === "string" && webhookUrl.length > 0;
+  const verbosityActive = typeof verbosity === "string" && verbosity !== "off";
+  return hasWebhook && verbosityActive;
+}
+
+function renderUnconfiguredState(): HTMLElement {
+  return createEmptyState(
+    "Notifications not configured",
+    "Configure a Slack webhook and set verbosity to start receiving notifications when issues complete, fail, or need attention.",
+    "Open notification settings",
+    () => router.navigate("/settings"),
+    "events",
+  );
+}
+
+function renderConfiguredState(): HTMLElement {
+  return createEmptyState(
+    "No notification history yet",
+    "Notifications are configured and will be sent as Slack messages when issues are processed. Delivery history will appear here in a future update.",
+    "Open board",
+    () => router.navigate("/queue"),
+    "events",
+  );
+}
+
+function renderErrorState(): HTMLElement {
+  return createEmptyState(
+    "Could not load notification status",
+    "Unable to check notification configuration. Try refreshing the page, or visit Settings to configure notifications manually.",
+    "Open settings",
+    () => router.navigate("/settings"),
+    "error",
+  );
+}
 
 export function createNotificationsPage(): HTMLElement {
   const page = document.createElement("div");
@@ -13,17 +54,20 @@ export function createNotificationsPage(): HTMLElement {
 
   const body = document.createElement("section");
   body.className = "page-body";
-  body.append(
-    createEmptyState(
-      "Notification history needs backend API support",
-      "This page will show webhook deliveries, Slack and system alerts, and notification history once the backend exposes notification delivery and alert timeline APIs. Until then, use Overview to open issue details for issue-specific events and Observability for live service signals.",
-      "Open overview",
-      () => router.navigate("/"),
-      "events",
-      { secondaryActionLabel: "Open observability", secondaryActionHref: "/observability" },
-    ),
-  );
+  body.append(skeletonBlock("200px"));
 
   page.append(header, body);
+
+  void loadNotificationStatus(body);
+
   return page;
+}
+
+async function loadNotificationStatus(body: HTMLElement): Promise<void> {
+  try {
+    const config = await api.getConfig();
+    body.replaceChildren(isSlackConfigured(config) ? renderConfiguredState() : renderUnconfiguredState());
+  } catch {
+    body.replaceChildren(renderErrorState());
+  }
 }


### PR DESCRIPTION
## Summary
- Replace the misleading "needs backend API support" notifications empty state with config-aware onboarding
- On page mount, fetch config via `api.getConfig()` and check `notifications.slack.webhook_url` + `notifications.slack.verbosity`
- If unconfigured: guide user to Settings to set up Slack webhooks
- If configured: confirm notifications are active, link to the board
- Graceful error handling with a fallback empty state if config fetch fails
- Reuse existing `getValueAtPath` from `settings-paths.ts` for nested config access

## Test plan
- [x] `pnpm run build` passes
- [x] `pnpm run lint` passes (0 errors, only pre-existing warnings)
- [x] `pnpm run format:check` passes
- [x] `pnpm test` passes (1791 tests, 0 failures)
- [x] `pnpm exec playwright test --project=smoke` passes (2 pre-existing model override failures unrelated to this change)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
