### PR TITLE
feat(frontend): add subscribeAllEvents SSE helper for logs streaming

### DIFF
--- a/frontend/src/state/event-source.ts
+++ b/frontend/src/state/event-source.ts
@@ -57,6 +57,11 @@ function openConnection(): void {
     if (customEventName) {
       window.dispatchEvent(new CustomEvent(customEventName, { detail: data.payload }));
     }
+    window.dispatchEvent(
+      new CustomEvent("symphony:any-event", {
+        detail: { type: data.type, payload: data.payload },
+      }),
+    );
   };
 
   eventSource.onerror = () => {
@@ -88,6 +93,8 @@ export interface AgentEventPayload {
   type: string;
   message: string;
   sessionId: string | null;
+  timestamp?: string;
+  content?: string | null;
 }
 
 export function subscribeIssueEvents(identifier: string, handler: (event: AgentEventPayload) => void): () => void {
@@ -139,4 +146,19 @@ export function subscribePollComplete(handler: () => void): () => void {
 
 export function subscribeSystemError(handler: (payload: unknown) => void): () => void {
   return subscribeEvent("symphony:system-error", handler);
+}
+
+export function subscribeAllEvents(
+  identifier: string,
+  handler: (event: { type: string; payload: Record<string, unknown> }) => void,
+): () => void {
+  const listener = (e: Event) => {
+    const detail = (e as CustomEvent).detail as { type: string; payload?: Record<string, unknown> };
+    const payload = detail.payload;
+    if (payload && typeof payload.identifier === "string" && payload.identifier === identifier) {
+      handler({ type: detail.type, payload });
+    }
+  };
+  window.addEventListener("symphony:any-event", listener);
+  return () => window.removeEventListener("symphony:any-event", listener);
 }

--- a/tests/frontend/event-source.test.ts
+++ b/tests/frontend/event-source.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   subscribeIssueEvents,
+  subscribeAllEvents,
   subscribeWorkerFailed,
   subscribeModelUpdated,
   subscribeWorkspaceEvent,
@@ -152,5 +153,66 @@ describe("subscribeSystemError", () => {
     unsub();
     fakeTarget.dispatchEvent(new CustomEvent("symphony:system-error", { detail: payload }));
     expect(handler).toHaveBeenCalledOnce();
+  });
+});
+
+describe("subscribeAllEvents", () => {
+  let handler: ReturnType<typeof vi.fn>;
+  let unsubscribe: () => void;
+
+  function dispatchAnyEvent(type: string, payload: Record<string, unknown>): void {
+    fakeTarget.dispatchEvent(new CustomEvent("symphony:any-event", { detail: { type, payload } }));
+  }
+
+  beforeEach(() => {
+    handler = vi.fn();
+  });
+
+  afterEach(() => {
+    unsubscribe?.();
+  });
+
+  it("calls handler when identifier matches", () => {
+    unsubscribe = subscribeAllEvents("ENG-1", handler);
+    dispatchAnyEvent("agent.event", { identifier: "ENG-1", message: "hello" });
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith({
+      type: "agent.event",
+      payload: { identifier: "ENG-1", message: "hello" },
+    });
+  });
+
+  it("ignores events for a different identifier", () => {
+    unsubscribe = subscribeAllEvents("ENG-1", handler);
+    dispatchAnyEvent("agent.event", { identifier: "ENG-2", message: "hello" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("ignores events without a payload", () => {
+    unsubscribe = subscribeAllEvents("ENG-1", handler);
+    fakeTarget.dispatchEvent(new CustomEvent("symphony:any-event", { detail: { type: "agent.event" } }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns an unsubscribe function that stops further calls", () => {
+    unsubscribe = subscribeAllEvents("ENG-1", handler);
+    unsubscribe();
+    dispatchAnyEvent("agent.event", { identifier: "ENG-1", message: "hello" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("forwards the event type along with the payload", () => {
+    unsubscribe = subscribeAllEvents("ENG-1", handler);
+    dispatchAnyEvent("issue.started", { identifier: "ENG-1", status: "running" });
+    dispatchAnyEvent("worker.failed", { identifier: "ENG-1", error: "timeout" });
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenNthCalledWith(1, {
+      type: "issue.started",
+      payload: { identifier: "ENG-1", status: "running" },
+    });
+    expect(handler).toHaveBeenNthCalledWith(2, {
+      type: "worker.failed",
+      payload: { identifier: "ENG-1", error: "timeout" },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Extends `AgentEventPayload` with optional `timestamp` and `content` fields for backward-compatible enrichment
- Dispatches `symphony:any-event` CustomEvent on every SSE message in the `onmessage` handler, enabling a single subscription point for all event types
- Adds `subscribeAllEvents(identifier, handler)` that filters the broadcast channel by issue identifier and forwards `{ type, payload }` to the handler
- Adds 5 unit tests: identifier match, mismatch, missing payload, unsubscribe cleanup, and multi-type forwarding

This is Unit 3 of 5 parallel work units replacing interval-based polling with SSE-driven real-time streaming on the logs page.

## Test plan
- [x] `pnpm run build` -- TypeScript compiles cleanly
- [x] `pnpm run lint` -- 0 errors (pre-existing warnings only)
- [x] `pnpm run format:check` -- all files pass Prettier
- [x] `pnpm test` -- 1801 backend tests pass
- [x] `pnpm run test:frontend` -- 179 frontend tests pass (includes 5 new tests)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
