### PR TITLE
feat(core): enrich agent.event SSE payload with timestamp and content

### DIFF
--- a/src/core/symphony-events.ts
+++ b/src/core/symphony-events.ts
@@ -35,6 +35,8 @@ export interface SymphonyEventMap {
     type: string;
     message: string;
     sessionId: string | null;
+    timestamp: string;
+    content: string | null;
   };
 
   /** A polling cycle completed. */

--- a/src/orchestrator/orchestrator-delegates.ts
+++ b/src/orchestrator/orchestrator-delegates.ts
@@ -159,6 +159,8 @@ function forwardToEventBus(deps: OrchestratorDeps, event: RuntimeEventRecord): v
     type: event.event,
     message: event.message,
     sessionId: event.sessionId ?? null,
+    timestamp: event.at,
+    content: event.content ?? null,
   });
 }
 


### PR DESCRIPTION
## Summary
- Adds `timestamp` and `content` fields to the `"agent.event"` SSE payload type in `SymphonyEventMap`
- Populates both fields from the existing `RuntimeEventRecord` in `forwardToEventBus()` (`event.at` and `event.content ?? null`)
- Purely additive change -- existing SSE consumers are unaffected since `JSON.stringify` forwards extra fields automatically

## Test plan
- [x] TypeScript compilation passes (`pnpm run build`)
- [x] ESLint passes with zero errors (`pnpm run lint`)
- [x] Prettier formatting verified (`pnpm run format:check`)
- [x] All 1796 backend tests pass (`pnpm test`)
- [x] All 174 frontend tests pass (`pnpm run test:frontend`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
