### PR TITLE
feat(frontend): replace logs page polling with SSE streaming and sort toggle

### DIFF
--- a/frontend/src/pages/logs-view.ts
+++ b/frontend/src/pages/logs-view.ts
@@ -7,7 +7,8 @@ import { loadArchiveLogs, loadLiveLogs } from "./logs-data";
 import { stringifyPayload } from "../utils/events";
 import { createIconButton } from "../ui/buttons.js";
 import { createIcon } from "../ui/icons.js";
-import { subscribeIssueLifecycle } from "../state/event-source.js";
+import { subscribeIssueLifecycle, subscribeAllEvents, type AgentEventPayload } from "../state/event-source.js";
+import { createLogBuffer, type SortDirection } from "../state/log-buffer.js";
 
 type Mode = "live" | "archive";
 type Density = "compact" | "comfortable";
@@ -62,9 +63,12 @@ export function createLogsPage(id: string): HTMLElement {
 
   const copyAllBtn = makeIconBtn("copy", "Copy all logs");
 
+  const sortToggle = makeIconBtn("sort", "Sort order");
+  sortToggle.title = "Newest first";
+
   const viewActions = document.createElement("div");
   viewActions.className = "logs-view-actions";
-  viewActions.append(densityToggle, autoToggle, expandToggle, copyAllBtn);
+  viewActions.append(sortToggle, densityToggle, autoToggle, expandToggle, copyAllBtn);
   controls.append(typeBar, search, viewActions);
 
   // ── Log scroll area ───────────────────────────────────────────────────────
@@ -77,7 +81,7 @@ export function createLogsPage(id: string): HTMLElement {
   indicator.hidden = true;
   indicator.textContent = "↓ New events";
   indicator.addEventListener("click", () => {
-    scroll.scrollTop = scroll.scrollHeight;
+    scroll.scrollTop = buffer.direction() === "desc" ? 0 : scroll.scrollHeight;
     newEventCount = 0;
     indicator.hidden = true;
   });
@@ -95,16 +99,18 @@ export function createLogsPage(id: string): HTMLElement {
   let unsubscribeLifecycle: (() => void) | null = null;
   const expandedEvents = new Set<string>();
   let newEventCount = 0;
+  const buffer = createLogBuffer("desc");
+  let unsubscribeStream: (() => void) | null = null;
 
   function filtered(): RecentEvent[] {
-    return data.events.filter((event) => {
+    return buffer.events().filter((event) => {
       const matchesType = activeFilters.size === 0 || activeFilters.has(event.event);
       return matchesType && eventMatchesSearch(event, searchText);
     });
   }
 
   function renderTypeFilters(): void {
-    const eventTypes = [...new Set(data.events.map((event) => event.event))];
+    const eventTypes = [...new Set(buffer.events().map((event) => event.event))];
 
     const allBtn = document.createElement("button");
     allBtn.type = "button";
@@ -143,6 +149,7 @@ export function createLogsPage(id: string): HTMLElement {
     autoToggle.classList.toggle("is-active", autoScroll);
     densityToggle.classList.toggle("is-active", density === "compact");
     expandToggle.classList.toggle("is-active", expandedEvents.size > 0);
+    sortToggle.classList.toggle("is-flipped", buffer.direction() === "asc");
     scroll.classList.toggle("is-compact", density === "compact");
     scroll.classList.toggle("is-comfortable", density === "comfortable");
     renderTypeFilters();
@@ -157,13 +164,13 @@ export function createLogsPage(id: string): HTMLElement {
           mode === "live" ? "Refresh logs" : "Switch to live logs",
           () => {
             if (mode === "live") {
-              void refresh(true);
+              void refresh();
               return;
             }
             mode = "live";
             render();
             restartPolling();
-            void refresh(true);
+            void refresh();
           },
         ),
       );
@@ -194,21 +201,59 @@ export function createLogsPage(id: string): HTMLElement {
       }),
     );
     if (autoScroll) {
-      scroll.scrollTop = scroll.scrollHeight;
+      scroll.scrollTop = buffer.direction() === "desc" ? 0 : scroll.scrollHeight;
     }
   }
 
-  async function refresh(force = false): Promise<void> {
-    const prevLength = data.events.length;
-    const prevLastAt = data.events.at(-1)?.at;
+  async function refresh(): Promise<void> {
     data = mode === "live" ? await loadLiveLogs(id) : await loadArchiveLogs(id);
-    const added = Math.max(0, data.events.length - prevLength);
-    const changed = force || data.events.length !== prevLength || data.events.at(-1)?.at !== prevLastAt;
-    if (changed) {
-      if (!autoScroll && added > 0 && !indicator.hidden) {
-        newEventCount += added;
-        indicator.textContent = `↓ ${newEventCount} new`;
-      }
+    buffer.load(data.events);
+    render();
+  }
+
+  function appendSingleEvent(event: RecentEvent): void {
+    const matchesType = activeFilters.size === 0 || activeFilters.has(event.event);
+    if (!matchesType || !eventMatchesSearch(event, searchText)) return;
+
+    const key = `${event.at}:${event.event}:${event.message}`;
+    const row = createLogRow({
+      event,
+      expanded: expandedEvents.has(key),
+      highlightedText: searchText,
+      onToggle: () => {
+        if (expandedEvents.has(key)) expandedEvents.delete(key);
+        else expandedEvents.add(key);
+        render();
+      },
+    });
+    row.classList.add("timeline-enter");
+
+    const visibleEvents = filtered();
+    const eventIndex = visibleEvents.indexOf(event);
+
+    const referenceNode = scroll.children[eventIndex] as Element | undefined;
+    if (referenceNode) {
+      scroll.insertBefore(row, referenceNode);
+    } else {
+      scroll.appendChild(row);
+    }
+
+    if (autoScroll) {
+      scroll.scrollTop = buffer.direction() === "desc" ? 0 : scroll.scrollHeight;
+    } else {
+      newEventCount++;
+      const arrow = buffer.direction() === "desc" ? "\u2191" : "\u2193";
+      indicator.textContent = `${arrow} ${newEventCount} new`;
+      indicator.hidden = false;
+    }
+  }
+
+  async function reconcile(): Promise<void> {
+    const fresh = mode === "live" ? await loadLiveLogs(id) : await loadArchiveLogs(id);
+    data = fresh;
+    const beforeSize = buffer.size();
+    buffer.load(fresh.events);
+    if (buffer.size() !== beforeSize) {
       render();
     }
   }
@@ -216,12 +261,29 @@ export function createLogsPage(id: string): HTMLElement {
   function restartPolling(): void {
     window.clearInterval(timer);
     unsubscribeLifecycle?.();
+    unsubscribeStream?.();
     unsubscribeLifecycle = null;
+    unsubscribeStream = null;
     if (mode === "live") {
-      timer = window.setInterval(() => {
-        void refresh();
-      }, 10_000);
-      unsubscribeLifecycle = subscribeIssueLifecycle(id, () => void refresh());
+      unsubscribeStream = subscribeAllEvents(id, (sseEvent) => {
+        if (sseEvent.type === "agent.event") {
+          const p = sseEvent.payload as unknown as AgentEventPayload;
+          const recentEvent: RecentEvent = {
+            at: p.timestamp ?? new Date().toISOString(),
+            issue_id: p.issueId ?? "",
+            issue_identifier: p.identifier ?? "",
+            session_id: p.sessionId ?? null,
+            event: p.type ?? "",
+            message: p.message ?? "",
+            content: p.content ?? null,
+          };
+          if (buffer.insert(recentEvent)) {
+            appendSingleEvent(recentEvent);
+          }
+        }
+      });
+      unsubscribeLifecycle = subscribeIssueLifecycle(id, () => void reconcile());
+      timer = window.setInterval(() => void reconcile(), 30_000);
     }
   }
 
@@ -230,14 +292,14 @@ export function createLogsPage(id: string): HTMLElement {
     mode = "live";
     render();
     restartPolling();
-    void refresh(true);
+    void refresh();
   });
   archiveBtn.addEventListener("click", () => {
     if (mode === "archive") return;
     mode = "archive";
     render();
     restartPolling();
-    void refresh(true);
+    void refresh();
   });
   autoToggle.addEventListener("click", () => {
     autoScroll = !autoScroll;
@@ -245,6 +307,12 @@ export function createLogsPage(id: string): HTMLElement {
   });
   densityToggle.addEventListener("click", () => {
     density = density === "compact" ? "comfortable" : "compact";
+    render();
+  });
+  sortToggle.addEventListener("click", () => {
+    const newDir: SortDirection = buffer.direction() === "desc" ? "asc" : "desc";
+    buffer.setDirection(newDir);
+    sortToggle.title = newDir === "desc" ? "Newest first" : "Oldest first";
     render();
   });
   expandToggle.addEventListener("click", () => {
@@ -284,11 +352,15 @@ export function createLogsPage(id: string): HTMLElement {
     render();
   });
   scroll.addEventListener("scroll", () => {
-    const nearBottom = scroll.scrollTop + scroll.clientHeight >= scroll.scrollHeight - 24;
-    indicator.hidden = nearBottom || autoScroll;
-    if (nearBottom) {
+    const isDesc = buffer.direction() === "desc";
+    const nearEdge = isDesc
+      ? scroll.scrollTop <= 24
+      : scroll.scrollTop + scroll.clientHeight >= scroll.scrollHeight - 24;
+    indicator.hidden = nearEdge || autoScroll;
+    if (nearEdge) {
       newEventCount = 0;
-      indicator.textContent = "↓ New events";
+      const arrow = isDesc ? "\u2191" : "\u2193";
+      indicator.textContent = `${arrow} New events`;
     }
   });
   // Make the shell outlet non-scrolling so logs-scroll is the true scroll boundary
@@ -306,6 +378,7 @@ export function createLogsPage(id: string): HTMLElement {
   registerPageCleanup(page, () => {
     window.clearInterval(timer);
     unsubscribeLifecycle?.();
+    unsubscribeStream?.();
   });
   return page;
 }

--- a/frontend/src/state/event-source.ts
+++ b/frontend/src/state/event-source.ts
@@ -57,6 +57,11 @@ function openConnection(): void {
     if (customEventName) {
       window.dispatchEvent(new CustomEvent(customEventName, { detail: data.payload }));
     }
+    window.dispatchEvent(
+      new CustomEvent("symphony:any-event", {
+        detail: { type: data.type, payload: data.payload },
+      }),
+    );
   };
 
   eventSource.onerror = () => {
@@ -88,6 +93,8 @@ export interface AgentEventPayload {
   type: string;
   message: string;
   sessionId: string | null;
+  timestamp?: string;
+  content?: string | null;
 }
 
 export function subscribeIssueEvents(identifier: string, handler: (event: AgentEventPayload) => void): () => void {
@@ -139,4 +146,22 @@ export function subscribePollComplete(handler: () => void): () => void {
 
 export function subscribeSystemError(handler: (payload: unknown) => void): () => void {
   return subscribeEvent("symphony:system-error", handler);
+}
+
+export function subscribeAllEvents(
+  identifier: string,
+  handler: (event: { type: string; payload: Record<string, unknown> }) => void,
+): () => void {
+  const listener = (e: Event) => {
+    const detail = (e as CustomEvent).detail as {
+      type: string;
+      payload?: Record<string, unknown>;
+    };
+    const payload = detail.payload;
+    if (payload && typeof payload.identifier === "string" && payload.identifier === identifier) {
+      handler({ type: detail.type, payload });
+    }
+  };
+  window.addEventListener("symphony:any-event", listener);
+  return () => window.removeEventListener("symphony:any-event", listener);
 }

--- a/frontend/src/state/log-buffer.ts
+++ b/frontend/src/state/log-buffer.ts
@@ -1,0 +1,73 @@
+/**
+ * Sorted, deduped log buffer for real-time log streaming.
+ * Events are kept in timestamp order (configurable direction).
+ * New events are inserted at the correct position via binary search.
+ */
+
+import type { RecentEvent } from "../types.js";
+
+export type SortDirection = "desc" | "asc";
+
+export interface LogBuffer {
+  events(): RecentEvent[];
+  insert(event: RecentEvent): boolean;
+  load(events: RecentEvent[]): void;
+  setDirection(direction: SortDirection): void;
+  direction(): SortDirection;
+  size(): number;
+}
+
+function eventKey(e: RecentEvent): string {
+  return `${e.at}|${e.event}|${e.message}|${e.session_id ?? ""}`;
+}
+
+export function createLogBuffer(initialDirection: SortDirection = "desc"): LogBuffer {
+  let dir = initialDirection;
+  const items: RecentEvent[] = [];
+  const seen = new Set<string>();
+
+  function compare(a: RecentEvent, b: RecentEvent): number {
+    const cmp = a.at < b.at ? -1 : a.at > b.at ? 1 : 0;
+    return dir === "desc" ? -cmp : cmp;
+  }
+
+  function binaryInsertIndex(event: RecentEvent): number {
+    let lo = 0;
+    let hi = items.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if (compare(items[mid], event) <= 0) lo = mid + 1;
+      else hi = mid;
+    }
+    return lo;
+  }
+
+  return {
+    events: () => items,
+    insert(event) {
+      const key = eventKey(event);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      const idx = binaryInsertIndex(event);
+      items.splice(idx, 0, event);
+      return true;
+    },
+    load(events) {
+      for (const e of events) {
+        const key = eventKey(e);
+        if (!seen.has(key)) {
+          seen.add(key);
+          items.push(e);
+        }
+      }
+      items.sort(compare);
+    },
+    setDirection(newDir) {
+      if (newDir === dir) return;
+      dir = newDir;
+      items.sort(compare);
+    },
+    direction: () => dir,
+    size: () => items.length,
+  };
+}

--- a/frontend/src/styles/logs.css
+++ b/frontend/src/styles/logs.css
@@ -102,6 +102,12 @@
   background: color-mix(in srgb, var(--color-copper-400) 18%, var(--bg-elevated));
 }
 
+/* Sort direction flip */
+.logs-icon-btn.is-flipped svg {
+  transform: scaleY(-1);
+  transition: transform var(--motion-fast) var(--ease-out-quart);
+}
+
 /* Filter chip active state */
 .mc-chip.is-interactive.is-active {
   background: var(--color-copper-400);


### PR DESCRIPTION
## Summary
- Replace 10-second interval polling in the logs page with SSE-driven real-time event streaming via `subscribeAllEvents`
- Add `LogBuffer` data structure for sorted, deduped event storage with binary search insert
- Add sort direction toggle button (newest-first default) to the logs toolbar
- Reduce reconciliation polling to 30s as a fallback for SSE gaps
- Incremental DOM updates via `insertBefore()`/`prepend()` for new SSE events

## Test plan
- [x] Build passes (`pnpm run build`)
- [x] Lint + format clean (`pnpm run lint && pnpm run format:check`)
- [x] Backend tests pass (1796 tests)
- [x] Frontend tests pass (174 tests)
- [x] Existing Playwright logs E2E smoke tests pass (10 tests)
- [ ] Manual: verify real-time event streaming with a live issue
- [ ] Manual: verify sort toggle reverses log row order
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/symphony-orchestrator/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
