### PR TITLE
docs: sync docs-site with v0.6.0 and land Mintlify upgrades

### DIFF
--- a/docs-site/.mintignore
+++ b/docs-site/.mintignore
@@ -3,3 +3,4 @@ node_modules/
 dist/
 coverage/
 *.log
+images/README.md

--- a/docs-site/api-reference/endpoints.mdx
+++ b/docs-site/api-reference/endpoints.mdx
@@ -13,6 +13,8 @@ Core orchestrator state, runtime metadata, real-time events, and observability.
 |--------|------|-------------|
 | `GET` | `/api/v1/state` | Full orchestrator snapshot — queued, running, completed issues and token totals |
 | `GET` | `/api/v1/runtime` | Runtime info — version, data directory, feature flags |
+| `GET` | `/api/v1/observability` | Aggregate observability snapshot — metrics summaries and health signals |
+| `GET` | `/api/v1/recovery` | Latest startup recovery report — orphaned attempts resolved on boot |
 | `POST` | `/api/v1/refresh` | Trigger an immediate poll/reconciliation cycle |
 | `GET` | `/api/v1/transitions` | Available state machine transitions per issue |
 | `GET` | `/metrics` | Prometheus-format service metrics |
@@ -111,6 +113,7 @@ Each issue can have multiple attempts. An attempt represents a single agent exec
 |--------|------|-------------|
 | `GET` | `/api/v1/:id/attempts` | List all attempts for an issue |
 | `GET` | `/api/v1/attempts/:aid` | Detail for a specific attempt including event timeline |
+| `GET` | `/api/v1/attempts/:aid/checkpoints` | Checkpoint history for an attempt — progress markers written by the agent runner |
 
 <CodeGroup>
 
@@ -120,6 +123,10 @@ curl http://127.0.0.1:4000/api/v1/ENG-123/attempts
 
 ```bash "Attempt detail"
 curl http://127.0.0.1:4000/api/v1/attempts/att_01234
+```
+
+```bash "Checkpoint history"
+curl http://127.0.0.1:4000/api/v1/attempts/att_01234/checkpoints
 ```
 
 </CodeGroup>
@@ -277,17 +284,138 @@ curl "http://127.0.0.1:4000/api/v1/audit?limit=50&offset=0"
 
 ---
 
+## Notifications
+
+Persistent notification timeline for run lifecycle alerts. Backed by the notification store and deduplicated per run.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/notifications` | List persisted notifications. Supports `limit` and `unread` query parameters |
+| `POST` | `/api/v1/notifications/:id/read` | Mark a single notification as read |
+| `POST` | `/api/v1/notifications/read-all` | Mark every notification as read |
+| `POST` | `/api/v1/notifications/test` | Send a test Slack notification using the saved webhook |
+
+<CodeGroup>
+
+```bash "List unread"
+curl "http://127.0.0.1:4000/api/v1/notifications?unread=true&limit=50"
+```
+
+```bash "Mark one read"
+curl -X POST http://127.0.0.1:4000/api/v1/notifications/ntf_01234/read
+```
+
+```bash "Send Slack test"
+curl -X POST http://127.0.0.1:4000/api/v1/notifications/test
+```
+
+</CodeGroup>
+
+<Tip>
+  The test endpoint reuses the Slack webhook configured under `notifications.channels` in your config overlay. See [Notifications setup](/guides/notifications) for channel configuration.
+</Tip>
+
+---
+
+## Automations
+
+Scheduled background automations — scheduler inspection and on-demand runs.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/automations` | List configured automations and current scheduler state |
+| `GET` | `/api/v1/automations/runs` | Historical automation runs. Supports `limit` and `automation_name` filters |
+| `POST` | `/api/v1/automations/:name/run` | Run a configured automation immediately |
+
+```bash "Run an automation now"
+curl -X POST http://127.0.0.1:4000/api/v1/automations/nightly-cleanup/run
+```
+
+---
+
+## Alerts
+
+Alert delivery history — each row records a rule evaluation, trigger, or cooldown event.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/alerts/history` | Paginated alert history. Supports `limit` and `rule_name` filters |
+
+```bash "Recent alerts"
+curl "http://127.0.0.1:4000/api/v1/alerts/history?limit=100"
+```
+
+---
+
 ## Webhooks
 
-Inbound webhook receivers for external integrations.
+Inbound webhook receivers for external integrations and an authenticated trigger dispatcher.
 
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/webhooks/linear` | Linear webhook receiver — processes issue and comment events |
+| `POST` | `/webhooks/github` | GitHub webhook receiver — processes repository and pull request events |
+| `POST` | `/api/v1/webhooks/trigger` | Dispatch an authenticated trigger action from an external system |
 
 <Tip>
-  Webhook endpoints have a separate rate limit of **600 requests/minute**. Configure the webhook URL in your Linear workspace settings.
+  Inbound receivers (`/webhooks/linear`, `/webhooks/github`) have a separate rate limit of **600 requests/minute**. Configure the webhook URL in the corresponding provider's workspace settings. `POST /api/v1/webhooks/trigger` requires the configured trigger credentials.
 </Tip>
+
+---
+
+## Codex Operator
+
+Operator routes that proxy to the embedded Codex control plane. Each route forwards to a JSON-RPC method on the Codex app-server session. See [Runtime concepts](/concepts/runtime) for context on the control-plane session lifecycle.
+
+### Session state
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/codex/capabilities` | Control-plane feature flags and reported capabilities |
+| `GET` | `/api/v1/codex/features` | List Codex experimental features. Supports `limit` and `cursor` |
+| `GET` | `/api/v1/codex/collaboration-modes` | List available Codex collaboration modes |
+
+### MCP servers
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/codex/mcp` | List MCP servers registered with Codex. Supports `limit` and `cursor` |
+| `POST` | `/api/v1/codex/mcp/oauth/login` | Begin an OAuth login flow for a named MCP server |
+| `POST` | `/api/v1/codex/mcp/reload` | Reload the MCP server configuration |
+
+### Threads
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/codex/threads` | List Codex threads. Supports `limit`, `cursor`, `sortKey`, `archived`, `modelProviders`, and `sourceKinds` |
+| `GET` | `/api/v1/codex/threads/loaded` | List threads currently loaded in memory |
+| `GET` | `/api/v1/codex/threads/:threadId` | Read a single thread. Pass `includeTurns=true` to return turn history |
+| `POST` | `/api/v1/codex/threads/:threadId/fork` | Fork a thread into a new session |
+| `POST` | `/api/v1/codex/threads/:threadId/name` | Rename a thread |
+| `POST` | `/api/v1/codex/threads/:threadId/archive` | Archive a thread |
+| `POST` | `/api/v1/codex/threads/:threadId/unarchive` | Unarchive a thread |
+| `POST` | `/api/v1/codex/threads/:threadId/unsubscribe` | Unsubscribe from a thread's event stream |
+
+### Account
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/codex/account` | Read the current Codex account |
+| `GET` | `/api/v1/codex/account/rate-limits` | Read Codex account rate-limit state |
+| `POST` | `/api/v1/codex/account/login/start` | Start a Codex login flow. Accepts `type` and `apiKey` |
+| `POST` | `/api/v1/codex/account/login/cancel` | Cancel an in-progress login by `loginId` |
+| `POST` | `/api/v1/codex/account/logout` | Log out of the Codex account |
+
+### Interactive input
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/codex/requests/user-input` | List pending user-input requests awaiting operator response |
+| `POST` | `/api/v1/codex/requests/user-input/:requestId/respond` | Respond to a pending request with a `result` payload |
+
+<Warning>
+  All Codex routes return **503** when the control plane is not configured or is unreachable, **502** when the underlying Codex request fails, and **501** when the requested method is not supported by the installed Codex version.
+</Warning>
 
 ---
 

--- a/docs-site/changelog.mdx
+++ b/docs-site/changelog.mdx
@@ -5,6 +5,17 @@ icon: "clock-rotate-left"
 ---
 
 
+<Update label="2026-04-10" description="Unreleased" tags={["Breaking", "Architecture", "Infra"]}>
+  ## v1 architecture rewrite, agent-readiness refactor, CI hardening
+
+  Post-v0.6.0 work on the v1 release branch. Not yet tagged.
+
+  - **v1 architecture rewrite** ([2aa37fa](https://github.com/OmerFarukOruc/risoluto/commit/2aa37fa)) — removed the JSONL write path, split five "God Views" into dedicated operator surfaces, replaced the DirtyTracking heuristic, isolated the Codex control plane from the rest of the runtime, and fixed a bubblewrap sandbox regression
+  - **Agent-readiness hooks** ([4167da1](https://github.com/OmerFarukOruc/risoluto/commit/4167da1)) — compaction-recovery hooks, guardrail hooks, and delegation hooks for Claude Code and Codex workflows, plus 9 rule files and a consolidated `@AGENTS.md` import
+  - **Dependabot + dead code + API contract + E2E selector fixes** ([1dd2461](https://github.com/OmerFarukOruc/risoluto/commit/1dd2461)) — resolved open dependabot alerts, pruned dead code, tightened the HTTP API contract, and stabilized Playwright selectors for the new v1 views
+  - Docs-site sync: added missing Notifications, Automations, Alerts, and Codex operator endpoint reference, `mergePolicy`, `stateMachine`, and multi-repo routing configuration, and webhook + container resource metric references
+</Update>
+
 <Update label="2026-03-31" description="v0.6.0" tags={["Feature", "Docs", "Rebrand"]}>
   ## Webhook integration, Mintlify docs, Risoluto rebrand
 

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -33,27 +33,11 @@
     }
   },
   "banner": {
-    "content": "Risoluto is in active development — [Star us on GitHub](https://github.com/OmerFarukOruc/risoluto) to follow along!",
+    "content": "Risoluto is in pre-launch beta — public availability targeted for May 2026. [Read the introduction](/introduction) or [star us on GitHub](https://github.com/OmerFarukOruc/risoluto) to follow along.",
     "dismissible": true
   },
   "contextual": {
-    "options": [
-      "copy",
-      "view",
-      "assistant",
-      "chatgpt",
-      "claude",
-      "perplexity",
-      "grok",
-      "aistudio",
-      "devin",
-      "windsurf",
-      "mcp",
-      "add-mcp",
-      "cursor",
-      "vscode",
-      "devin-mcp"
-    ]
+    "options": ["copy", "view", "assistant", "chatgpt", "claude", "perplexity", "grok", "aistudio", "devin", "windsurf"]
   },
   "search": {
     "prompt": "Search Risoluto docs..."
@@ -141,8 +125,35 @@
     "socials": {
       "github": "https://github.com/OmerFarukOruc/risoluto",
       "website": "https://risolu.to"
-    }
+    },
+    "links": [
+      {
+        "header": "Docs",
+        "items": [
+          { "label": "Quickstart", "href": "/quickstart" },
+          { "label": "Configuration", "href": "/guides/configuration" },
+          { "label": "API Reference", "href": "/api-reference/overview" },
+          { "label": "Changelog", "href": "/changelog" }
+        ]
+      },
+      {
+        "header": "Resources",
+        "items": [
+          { "label": "GitHub", "href": "https://github.com/OmerFarukOruc/risoluto" },
+          { "label": "Issues", "href": "https://github.com/OmerFarukOruc/risoluto/issues" },
+          { "label": "Releases", "href": "https://github.com/OmerFarukOruc/risoluto/releases" }
+        ]
+      }
+    ]
   },
+  "redirects": [
+    { "source": "/symphony", "destination": "/" },
+    { "source": "/symphony/:path*", "destination": "/" },
+    { "source": "/docs", "destination": "/" },
+    { "source": "/docs/:path*", "destination": "/:path*" },
+    { "source": "/api", "destination": "/api-reference/overview" },
+    { "source": "/api/:path*", "destination": "/api-reference/endpoints" }
+  ],
   "seo": {
     "indexing": "all",
     "metatags": {

--- a/docs-site/guides/configuration.mdx
+++ b/docs-site/guides/configuration.mdx
@@ -188,10 +188,57 @@ Risoluto's configuration is layered with this merge order (last wins):
   </Accordion>
 
   <Accordion title="Notifications">
+    Risoluto supports two notification config shapes. The single-Slack shape is the legacy path; the `channels` array is the current multi-channel path and is what you should use for anything beyond a single Slack webhook.
+
+    **Legacy single-Slack:**
+
     | Key | Type | Default | Description |
     |-----|------|---------|-------------|
     | `notifications.slack.webhookUrl` | string | — | Slack incoming webhook URL |
     | `notifications.slack.verbosity` | enum | `"critical"` | `off`, `critical`, `verbose` |
+
+    **Multi-channel array:**
+
+    | Key | Type | Default | Description |
+    |-----|------|---------|-------------|
+    | `notifications.channels[]` | array | `[]` | Delivery channels, evaluated in order |
+    | `notifications.channels[].name` | string | — | Unique channel label used in notification metadata |
+    | `notifications.channels[].enabled` | boolean | `true` | Disable without removing the entry |
+    | `notifications.channels[].minSeverity` | enum | `"info"` | `info`, `warning`, `critical` — only notifications at or above this severity are delivered |
+    | `notifications.channels[].type` | enum | — | `slack`, `webhook`, or `desktop` |
+
+    **Slack channel** (`type: slack`):
+
+    | Key | Type | Default | Description |
+    |-----|------|---------|-------------|
+    | `webhookUrl` | string | — | Slack incoming webhook URL (prefer `$SECRET:SLACK_WEBHOOK_URL`) |
+    | `verbosity` | enum | `"critical"` | `off`, `critical`, `verbose` |
+
+    **Webhook channel** (`type: webhook`):
+
+    | Key | Type | Default | Description |
+    |-----|------|---------|-------------|
+    | `url` | string | — | HTTPS endpoint to POST notification payloads to |
+    | `headers` | object | `{}` | Extra HTTP headers (e.g. `Authorization: Bearer ...`) |
+
+    **Desktop channel** (`type: desktop`): no extra fields — surfaces notifications in the dashboard notification tray only.
+
+    ```yaml
+    notifications:
+      channels:
+        - name: ops-slack
+          type: slack
+          minSeverity: warning
+          webhookUrl: $SECRET:SLACK_WEBHOOK_URL
+        - name: oncall-pager
+          type: webhook
+          minSeverity: critical
+          url: https://events.example.com/risoluto
+          headers:
+            Authorization: Bearer $SECRET:PAGER_TOKEN
+        - name: dashboard-only
+          type: desktop
+    ```
 
     See the [Notifications guide](/guides/notifications) for event types and severity levels.
   </Accordion>
@@ -211,6 +258,59 @@ Risoluto's configuration is layered with this merge order (last wins):
     |-----|------|---------|-------------|
     | `github.token` | string | — | GitHub Personal Access Token |
     | `github.apiBaseUrl` | string | `"https://api.github.com"` | GitHub API endpoint (for GHES) |
+  </Accordion>
+
+  <Accordion title="Multi-repo routing">
+    Route issues to different repositories based on tracker metadata. Each entry in `repos` is a destination that the orchestrator matches against the incoming issue before launching a worker. See the [Multi-repo recipe](/recipes/multi-repo) for a worked example.
+
+    | Key | Type | Default | Description |
+    |-----|------|---------|-------------|
+    | `repos[]` | array | `[]` | Repository routing entries |
+    | `repos[].repoUrl` | string | — | Git URL used to clone or fetch the workspace |
+    | `repos[].defaultBranch` | string | `"main"` | Branch agents branch from |
+    | `repos[].identifierPrefix` | string \| null | `null` | Match issues whose identifier starts with this prefix (e.g. `"ENG-"`) |
+    | `repos[].label` | string \| null | `null` | Match issues that carry this label |
+    | `repos[].githubOwner` | string \| null | `null` | GitHub owner used when the orchestrator opens the PR |
+    | `repos[].githubRepo` | string \| null | `null` | GitHub repo name used for the PR |
+    | `repos[].githubTokenEnv` | string \| null | `null` | Name of the env var holding the PR-creation token for this repo |
+  </Accordion>
+
+  <Accordion title="Merge policy">
+    Controls the opt-in auto-merge engine. Defaults to disabled, so no PR is auto-merged until you turn `enabled` on.
+
+    | Key | Type | Default | Description |
+    |-----|------|---------|-------------|
+    | `mergePolicy.enabled` | boolean | `false` | Master switch. When `false`, Risoluto never requests an auto-merge |
+    | `mergePolicy.allowedPaths` | string[] | `[]` | Path prefixes; when non-empty, every changed file in the PR must match at least one entry |
+    | `mergePolicy.maxChangedFiles` | number \| null | `null` | Maximum number of changed files. `null` disables the cap |
+    | `mergePolicy.maxDiffLines` | number \| null | `null` | Maximum combined additions + deletions. `null` disables the cap |
+    | `mergePolicy.requireLabels` | string[] | `[]` | Labels that must all be present on the PR before auto-merge is attempted |
+    | `mergePolicy.excludeLabels` | string[] | `[]` | Labels that block auto-merge when any are present |
+  </Accordion>
+
+  <Accordion title="State machine (custom stages)">
+    Override the default issue lifecycle stages and transitions. Only needed if your tracker uses non-standard states or you want to gate specific transitions.
+
+    | Key | Type | Default | Description |
+    |-----|------|---------|-------------|
+    | `stateMachine.stages[]` | array | `[]` | Ordered stage list |
+    | `stateMachine.stages[].name` | string | — | Stage label that must match a tracker state name |
+    | `stateMachine.stages[].kind` | enum | — | One of `backlog`, `todo`, `active`, `gate`, `terminal` |
+    | `stateMachine.transitions` | object | `{}` | Map of stage name to an array of allowed next stage names |
+
+    ```yaml
+    stateMachine:
+      stages:
+        - { name: Backlog, kind: backlog }
+        - { name: Ready, kind: todo }
+        - { name: In Progress, kind: active }
+        - { name: Review, kind: gate }
+        - { name: Done, kind: terminal }
+      transitions:
+        Ready: [In Progress]
+        In Progress: [Review, Ready]
+        Review: [Done, In Progress]
+    ```
   </Accordion>
 </AccordionGroup>
 
@@ -250,6 +350,7 @@ curl -s -X DELETE http://127.0.0.1:4000/api/v1/secrets/SLACK_WEBHOOK_URL
 | `DATA_DIR` | No | `~/.risoluto` | Root directory for archives and config |
 | `RISOLUTO_BIND` | No | `127.0.0.1` | HTTP bind address |
 | `RISOLUTO_WRITE_TOKEN` | No | — | Bearer token for remote API writes |
+| `RISOLUTO_READ_TOKEN` | No | — | Bearer token required for remote reads when `RISOLUTO_BIND` is non-loopback. Unset when binding to `127.0.0.1`/`::1` |
 | `LOG_LEVEL` | No | `info` | Log verbosity |
 | `DISPATCH_MODE` | No | `local` | `local` or `remote` dispatch mode |
 | `DISPATCH_URL` | No | — | Data plane URL (when `DISPATCH_MODE=remote`) |

--- a/docs-site/guides/dashboard.mdx
+++ b/docs-site/guides/dashboard.mdx
@@ -47,6 +47,22 @@ Risoluto serves a live operator dashboard at `http://127.0.0.1:4000`. It is the 
   </Card>
 </CardGroup>
 
+## v1 operator surfaces
+
+The v1 architecture rewrite split several cross-cutting views out of the old "God View" settings page. These routes are top-level pages in the navigation.
+
+<CardGroup cols={3}>
+  <Card title="Containers" icon="docker" href="/guides/docker">
+    Inspect sandbox container state, resource usage, and lifecycle events. Reached at `/containers` in the dashboard.
+  </Card>
+  <Card title="Observability" icon="chart-line" href="/operating/observability">
+    Live metrics dashboard backed by the orchestrator, webhook, and container resource meters. Reached at `/observability`.
+  </Card>
+  <Card title="Notifications" icon="bell" href="/guides/notifications">
+    Persistent notification timeline with severity filters. Mark items read or send a Slack test from the same page. Reached at `/notifications`.
+  </Card>
+</CardGroup>
+
 ## Real-time events
 
 The dashboard subscribes to `GET /api/v1/events` over SSE, so most screens update without a manual refresh.

--- a/docs-site/images/README.md
+++ b/docs-site/images/README.md
@@ -1,0 +1,19 @@
+# Image assets
+
+This directory holds image assets referenced by `docs-site/docs.json` and the MDX content.
+
+## Missing asset: `og-image.png`
+
+`docs.json` references `/images/og-image.png` for both `og:image` and `twitter:image` SEO
+meta tags. The binary itself is not yet in the repo, so every social share currently
+renders without a preview card.
+
+Required spec:
+
+- **Format:** PNG
+- **Dimensions:** 1200 × 630 pixels (standard Open Graph ratio)
+- **Filename:** `og-image.png`
+- **Location:** `docs-site/images/og-image.png`
+
+Once the asset is added, no config changes are needed — the path in `docs.json` already
+points at `/images/og-image.png`.

--- a/docs-site/introduction.mdx
+++ b/docs-site/introduction.mdx
@@ -8,9 +8,13 @@ icon: "house"
 
 Risoluto is a local orchestration engine that watches your tracker for actionable issues, launches sandboxed AI coding agents inside Docker, and reports the result through pull requests, dashboard state, and API events.
 
-```
+```text
 You move an issue into an active state → Risoluto claims it → an agent works in an isolated workspace → you review the result
 ```
+
+<Note>
+  **Pre-launch beta.** Risoluto is in pre-launch beta; public availability is targeted for May 2026. Interfaces, config shapes, and defaults may still shift between now and the public release — pin to a specific commit if you need stability today.
+</Note>
 
 <Check>
   **First time here?** Start with the [Quickstart](/quickstart). The recommended path is **Docker Compose → setup wizard

--- a/docs-site/openapi.json
+++ b/docs-site/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Risoluto API",
-    "version": "0.4.0",
+    "version": "0.6.0",
     "description": "REST API for Risoluto — manages issues, workspaces, config, and agent lifecycle."
   },
   "servers": [
@@ -2075,12 +2075,12 @@
                       "type": "string"
                     },
                     "feature_flags": {
+                      "default": {},
                       "type": "object",
                       "propertyNames": {
                         "type": "string"
                       },
-                      "additionalProperties": {},
-                      "default": {}
+                      "additionalProperties": {}
                     },
                     "provider_summary": {
                       "type": "string"
@@ -10658,6 +10658,2377 @@
           },
           "404": {
             "description": "Secret not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/capabilities": {
+      "get": {
+        "tags": ["Codex"],
+        "summary": "Get Codex control-plane capabilities",
+        "operationId": "getCodexCapabilities",
+        "responses": {
+          "200": {
+            "description": "Codex capability metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/features": {
+      "get": {
+        "tags": ["Codex"],
+        "summary": "List Codex experimental features",
+        "operationId": "listCodexFeatures",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Experimental feature list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/collaboration-modes": {
+      "get": {
+        "tags": ["Codex"],
+        "summary": "List Codex collaboration modes",
+        "operationId": "listCodexCollaborationModes",
+        "responses": {
+          "200": {
+            "description": "Collaboration mode list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/mcp": {
+      "get": {
+        "tags": ["Codex"],
+        "summary": "List MCP servers registered with Codex",
+        "operationId": "listCodexMcpServers",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "MCP server status list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/mcp/oauth/login": {
+      "post": {
+        "tags": ["Codex"],
+        "summary": "Begin OAuth login for an MCP server",
+        "operationId": "loginCodexMcpOauth",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": ["name"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OAuth login initiated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/mcp/reload": {
+      "post": {
+        "tags": ["Codex"],
+        "summary": "Reload MCP server configuration",
+        "operationId": "reloadCodexMcp",
+        "responses": {
+          "200": {
+            "description": "MCP configuration reloaded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/threads": {
+      "get": {
+        "tags": ["Codex"],
+        "summary": "List Codex threads",
+        "operationId": "listCodexThreads",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["created_at", "updated_at"]
+            }
+          },
+          {
+            "name": "archived",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "modelProviders",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated provider list"
+          },
+          {
+            "name": "sourceKinds",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated source-kind list"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Thread list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/threads/loaded": {
+      "get": {
+        "tags": ["Codex"],
+        "summary": "List currently loaded Codex threads",
+        "operationId": "listLoadedCodexThreads",
+        "responses": {
+          "200": {
+            "description": "Loaded thread list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/threads/{thread_id}": {
+      "get": {
+        "tags": ["Codex"],
+        "summary": "Read a single Codex thread",
+        "operationId": "readCodexThread",
+        "parameters": [
+          {
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Codex thread identifier"
+          },
+          {
+            "name": "includeTurns",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Thread detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/threads/{thread_id}/fork": {
+      "post": {
+        "tags": ["Codex"],
+        "summary": "Fork a Codex thread",
+        "operationId": "forkCodexThread",
+        "parameters": [
+          {
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Codex thread identifier"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Fork created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/threads/{thread_id}/name": {
+      "post": {
+        "tags": ["Codex"],
+        "summary": "Rename a Codex thread",
+        "operationId": "renameCodexThread",
+        "parameters": [
+          {
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Codex thread identifier"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": ["name"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Thread renamed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/threads/{thread_id}/archive": {
+      "post": {
+        "tags": ["Codex"],
+        "summary": "Archive a Codex thread",
+        "operationId": "archiveCodexThread",
+        "parameters": [
+          {
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Codex thread identifier"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Thread archived",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/threads/{thread_id}/unarchive": {
+      "post": {
+        "tags": ["Codex"],
+        "summary": "Unarchive a Codex thread",
+        "operationId": "unarchiveCodexThread",
+        "parameters": [
+          {
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Codex thread identifier"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Thread unarchived",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/threads/{thread_id}/unsubscribe": {
+      "post": {
+        "tags": ["Codex"],
+        "summary": "Unsubscribe from a Codex thread",
+        "operationId": "unsubscribeCodexThread",
+        "parameters": [
+          {
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Codex thread identifier"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unsubscribed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/account": {
+      "get": {
+        "tags": ["Codex"],
+        "summary": "Read the Codex account",
+        "operationId": "readCodexAccount",
+        "responses": {
+          "200": {
+            "description": "Account details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/account/rate-limits": {
+      "get": {
+        "tags": ["Codex"],
+        "summary": "Read Codex account rate limits",
+        "operationId": "readCodexAccountRateLimits",
+        "responses": {
+          "200": {
+            "description": "Rate-limit snapshot",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/account/login/start": {
+      "post": {
+        "tags": ["Codex"],
+        "summary": "Start a Codex account login flow",
+        "operationId": "startCodexAccountLogin",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "apiKey": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Login flow started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/account/login/cancel": {
+      "post": {
+        "tags": ["Codex"],
+        "summary": "Cancel an in-progress Codex account login",
+        "operationId": "cancelCodexAccountLogin",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "loginId": {
+                    "type": "string"
+                  }
+                },
+                "required": ["loginId"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Login flow cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/account/logout": {
+      "post": {
+        "tags": ["Codex"],
+        "summary": "Log the Codex account out",
+        "operationId": "logoutCodexAccount",
+        "responses": {
+          "200": {
+            "description": "Logged out",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Unsupported Codex control-plane method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Codex control-plane request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/requests/user-input": {
+      "get": {
+        "tags": ["Codex"],
+        "summary": "List pending Codex user-input requests",
+        "operationId": "listCodexUserInputRequests",
+        "responses": {
+          "200": {
+            "description": "Pending user-input requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/codex/requests/user-input/{request_id}/respond": {
+      "post": {
+        "tags": ["Codex"],
+        "summary": "Respond to a pending Codex user-input request",
+        "operationId": "respondToCodexUserInputRequest",
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pending request identifier"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "result": {}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Response accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Pending request not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["code", "message"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Codex control plane is unavailable",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs-site/operating/observability.mdx
+++ b/docs-site/operating/observability.mdx
@@ -58,6 +58,8 @@ Risoluto provides multiple observability surfaces: Prometheus metrics, real-time
         | Metric | Type | Labels | Description |
         |--------|------|--------|-------------|
         | `risoluto_agent_runs_total` | Counter | `outcome` | Agent completions (completed, failed, oom, stalled) |
+        | `risoluto_container_cpu_percent` | Gauge | `container` | Sandbox container CPU usage percentage |
+        | `risoluto_container_memory_percent` | Gauge | `container` | Sandbox container memory usage percentage |
 
         **Useful queries:**
 
@@ -68,6 +70,42 @@ Risoluto provides multiple observability surfaces: Prometheus metrics, real-time
 
         # Runs by outcome (stacked chart)
         sum by (outcome) (increase(risoluto_agent_runs_total[1h]))
+
+        # Containers at CPU saturation
+        max by (container) (risoluto_container_cpu_percent) > 90
+        ```
+      </Accordion>
+
+      <Accordion title="Webhook metrics">
+        Webhook delivery pipeline metrics — ingest volume, duplicate rejection, DLQ routing, backlog depth, and end-to-end processing latency.
+
+        | Metric | Type | Labels | Description |
+        |--------|------|--------|-------------|
+        | `risoluto_webhook_deliveries_total` | Counter | `provider`, `status` | Raw webhook deliveries received |
+        | `risoluto_webhook_duplicates_total` | Counter | `provider` | Deliveries rejected as duplicates by the idempotency store |
+        | `risoluto_webhook_events_processed_total` | Counter | `provider`, `outcome` | Events that passed validation and reached the processor |
+        | `risoluto_webhook_processor_retries_total` | Counter | `provider`, `reason` | Retry attempts inside the webhook processor |
+        | `risoluto_webhook_dlq_total` | Counter | `reason` | Events moved to the dead-letter queue |
+        | `risoluto_webhook_subscription_checks_total` | Counter | `provider`, `status` | Subscription health checks performed |
+        | `risoluto_webhook_backlog_count` | Gauge | `provider` | Current count of unprocessed webhook events |
+        | `risoluto_webhook_dlq_count` | Gauge | — | Current count of events in the dead-letter queue |
+        | `risoluto_webhook_last_delivery_age_seconds` | Gauge | `provider` | Seconds since the last successful delivery |
+        | `risoluto_webhook_processing_latency_seconds` | Histogram | `provider` | End-to-end webhook processing latency |
+
+        **Useful queries:**
+
+        ```promql
+        # Webhook backlog growing
+        max(risoluto_webhook_backlog_count) > 100
+
+        # DLQ accumulating
+        increase(risoluto_webhook_dlq_total[15m]) > 0
+
+        # Delivery staleness (webhook feed broken)
+        max(risoluto_webhook_last_delivery_age_seconds) > 900
+
+        # P95 webhook processing latency
+        histogram_quantile(0.95, rate(risoluto_webhook_processing_latency_seconds_bucket[5m]))
         ```
       </Accordion>
     </AccordionGroup>

--- a/docs-site/operating/troubleshooting.mdx
+++ b/docs-site/operating/troubleshooting.mdx
@@ -59,13 +59,17 @@ icon: "wrench"
 
     **Fix:** Use the correct master key, or factory reset:
 
-    ```bash
-    # Docker Compose factory reset
-    docker compose down -v && docker compose up --build -d
+    <CodeGroup>
 
-    # Manual reset — removes all encrypted secrets
+    ```bash "Docker Compose reset"
+    docker compose down -v && docker compose up --build -d
+    ```
+
+    ```bash "Manual reset"
     rm .risoluto/secrets.enc .risoluto/master.key
     ```
+
+    </CodeGroup>
 
     <Warning>
       Factory reset deletes all stored credentials. You will need to re-run the setup wizard.

--- a/docs-site/quickstart.mdx
+++ b/docs-site/quickstart.mdx
@@ -37,7 +37,7 @@ Get Risoluto running, finish the setup wizard, and confirm the pipeline with one
   </Step>
 
 <Step title="Open the local dashboard" icon="browser">
-  Visit `http://127.0.0.1:4000` in your browser. On first boot, Risoluto redirects you straight into the setup wizard.
+  Visit `http://localhost:4000` in your browser. On first boot, Risoluto redirects you straight into the setup wizard.
 </Step>
 
   <Step title="Finish the setup wizard" icon="wand-magic-sparkles">
@@ -79,7 +79,7 @@ Get Risoluto running, finish the setup wizard, and confirm the pipeline with one
     You can also confirm from the API:
 
     ```bash
-    curl -s http://127.0.0.1:4000/api/v1/state | jq
+    curl -s http://localhost:4000/api/v1/state | jq
     ```
 
   </Step>
@@ -119,6 +119,10 @@ If the run succeeds, inspect the generated proof file in your workspace root. Fo
     ```
 
     Then open `http://127.0.0.1:4000` and complete the same setup wizard.
+
+    <Tip>
+      Use `--data-dir /path/to/data` to override the default data directory (`~/.risoluto`). You can also set the `DATA_DIR` environment variable — the CLI flag wins when both are provided.
+    </Tip>
 
   </Accordion>
 </AccordionGroup>

--- a/src/http/openapi-paths.ts
+++ b/src/http/openapi-paths.ts
@@ -673,3 +673,289 @@ function buildSecretsPaths(): Record<string, PathItem> {
     },
   };
 }
+
+/**
+ * Codex operator routes proxy to the Codex control plane via JSON-RPC.
+ * Responses are opaque JSON objects forwarded from Codex, so schemas use a
+ * loose object shape rather than strict Zod types.
+ */
+const codexOpaqueObject: JsonSchema = { type: "object", additionalProperties: true };
+
+function codexResponse(description: string): Record<string, unknown> {
+  return {
+    "200": jsonResponse(description, codexOpaqueObject),
+    "501": errorResponse("Unsupported Codex control-plane method"),
+    "502": errorResponse("Codex control-plane request failed"),
+    "503": errorResponse("Codex control plane is unavailable"),
+  };
+}
+
+export function buildCodexPaths(): Record<string, PathItem> {
+  return {
+    "/api/v1/codex/capabilities": {
+      get: {
+        tags: ["Codex"],
+        summary: "Get Codex control-plane capabilities",
+        operationId: "getCodexCapabilities",
+        responses: codexResponse("Codex capability metadata"),
+      },
+    },
+    "/api/v1/codex/features": {
+      get: {
+        tags: ["Codex"],
+        summary: "List Codex experimental features",
+        operationId: "listCodexFeatures",
+        parameters: [
+          { name: "limit", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 500 } },
+          { name: "cursor", in: "query", required: false, schema: { type: "string" } },
+        ],
+        responses: codexResponse("Experimental feature list"),
+      },
+    },
+    "/api/v1/codex/collaboration-modes": {
+      get: {
+        tags: ["Codex"],
+        summary: "List Codex collaboration modes",
+        operationId: "listCodexCollaborationModes",
+        responses: codexResponse("Collaboration mode list"),
+      },
+    },
+    "/api/v1/codex/mcp": {
+      get: {
+        tags: ["Codex"],
+        summary: "List MCP servers registered with Codex",
+        operationId: "listCodexMcpServers",
+        parameters: [
+          { name: "limit", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 500 } },
+          { name: "cursor", in: "query", required: false, schema: { type: "string" } },
+        ],
+        responses: codexResponse("MCP server status list"),
+      },
+    },
+    "/api/v1/codex/mcp/oauth/login": {
+      post: {
+        tags: ["Codex"],
+        summary: "Begin OAuth login for an MCP server",
+        operationId: "loginCodexMcpOauth",
+        requestBody: {
+          required: true,
+          content: jsonContent({
+            type: "object",
+            properties: { name: { type: "string" } },
+            required: ["name"],
+          }),
+        },
+        responses: codexResponse("OAuth login initiated"),
+      },
+    },
+    "/api/v1/codex/mcp/reload": {
+      post: {
+        tags: ["Codex"],
+        summary: "Reload MCP server configuration",
+        operationId: "reloadCodexMcp",
+        responses: codexResponse("MCP configuration reloaded"),
+      },
+    },
+    "/api/v1/codex/threads": {
+      get: {
+        tags: ["Codex"],
+        summary: "List Codex threads",
+        operationId: "listCodexThreads",
+        parameters: [
+          { name: "limit", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 500 } },
+          { name: "cursor", in: "query", required: false, schema: { type: "string" } },
+          {
+            name: "sortKey",
+            in: "query",
+            required: false,
+            schema: { type: "string", enum: ["created_at", "updated_at"] },
+          },
+          { name: "archived", in: "query", required: false, schema: { type: "boolean" } },
+          {
+            name: "modelProviders",
+            in: "query",
+            required: false,
+            schema: { type: "string" },
+            description: "Comma-separated provider list",
+          },
+          {
+            name: "sourceKinds",
+            in: "query",
+            required: false,
+            schema: { type: "string" },
+            description: "Comma-separated source-kind list",
+          },
+        ],
+        responses: codexResponse("Thread list"),
+      },
+    },
+    "/api/v1/codex/threads/loaded": {
+      get: {
+        tags: ["Codex"],
+        summary: "List currently loaded Codex threads",
+        operationId: "listLoadedCodexThreads",
+        responses: codexResponse("Loaded thread list"),
+      },
+    },
+    "/api/v1/codex/threads/{thread_id}": {
+      get: {
+        tags: ["Codex"],
+        summary: "Read a single Codex thread",
+        operationId: "readCodexThread",
+        parameters: [
+          pathParam("thread_id", "Codex thread identifier"),
+          { name: "includeTurns", in: "query", required: false, schema: { type: "boolean" } },
+        ],
+        responses: codexResponse("Thread detail"),
+      },
+    },
+    "/api/v1/codex/threads/{thread_id}/fork": {
+      post: {
+        tags: ["Codex"],
+        summary: "Fork a Codex thread",
+        operationId: "forkCodexThread",
+        parameters: [pathParam("thread_id", "Codex thread identifier")],
+        responses: codexResponse("Fork created"),
+      },
+    },
+    "/api/v1/codex/threads/{thread_id}/name": {
+      post: {
+        tags: ["Codex"],
+        summary: "Rename a Codex thread",
+        operationId: "renameCodexThread",
+        parameters: [pathParam("thread_id", "Codex thread identifier")],
+        requestBody: {
+          required: true,
+          content: jsonContent({
+            type: "object",
+            properties: { name: { type: "string" } },
+            required: ["name"],
+          }),
+        },
+        responses: codexResponse("Thread renamed"),
+      },
+    },
+    "/api/v1/codex/threads/{thread_id}/archive": {
+      post: {
+        tags: ["Codex"],
+        summary: "Archive a Codex thread",
+        operationId: "archiveCodexThread",
+        parameters: [pathParam("thread_id", "Codex thread identifier")],
+        responses: codexResponse("Thread archived"),
+      },
+    },
+    "/api/v1/codex/threads/{thread_id}/unarchive": {
+      post: {
+        tags: ["Codex"],
+        summary: "Unarchive a Codex thread",
+        operationId: "unarchiveCodexThread",
+        parameters: [pathParam("thread_id", "Codex thread identifier")],
+        responses: codexResponse("Thread unarchived"),
+      },
+    },
+    "/api/v1/codex/threads/{thread_id}/unsubscribe": {
+      post: {
+        tags: ["Codex"],
+        summary: "Unsubscribe from a Codex thread",
+        operationId: "unsubscribeCodexThread",
+        parameters: [pathParam("thread_id", "Codex thread identifier")],
+        responses: codexResponse("Unsubscribed"),
+      },
+    },
+    "/api/v1/codex/account": {
+      get: {
+        tags: ["Codex"],
+        summary: "Read the Codex account",
+        operationId: "readCodexAccount",
+        responses: codexResponse("Account details"),
+      },
+    },
+    "/api/v1/codex/account/rate-limits": {
+      get: {
+        tags: ["Codex"],
+        summary: "Read Codex account rate limits",
+        operationId: "readCodexAccountRateLimits",
+        responses: codexResponse("Rate-limit snapshot"),
+      },
+    },
+    "/api/v1/codex/account/login/start": {
+      post: {
+        tags: ["Codex"],
+        summary: "Start a Codex account login flow",
+        operationId: "startCodexAccountLogin",
+        requestBody: {
+          required: true,
+          content: jsonContent({
+            type: "object",
+            properties: {
+              type: { type: "string" },
+              apiKey: { type: "string" },
+            },
+          }),
+        },
+        responses: codexResponse("Login flow started"),
+      },
+    },
+    "/api/v1/codex/account/login/cancel": {
+      post: {
+        tags: ["Codex"],
+        summary: "Cancel an in-progress Codex account login",
+        operationId: "cancelCodexAccountLogin",
+        requestBody: {
+          required: true,
+          content: jsonContent({
+            type: "object",
+            properties: { loginId: { type: "string" } },
+            required: ["loginId"],
+          }),
+        },
+        responses: codexResponse("Login flow cancelled"),
+      },
+    },
+    "/api/v1/codex/account/logout": {
+      post: {
+        tags: ["Codex"],
+        summary: "Log the Codex account out",
+        operationId: "logoutCodexAccount",
+        responses: codexResponse("Logged out"),
+      },
+    },
+    "/api/v1/codex/requests/user-input": {
+      get: {
+        tags: ["Codex"],
+        summary: "List pending Codex user-input requests",
+        operationId: "listCodexUserInputRequests",
+        responses: {
+          "200": jsonResponse("Pending user-input requests", {
+            type: "object",
+            properties: { data: { type: "array", items: codexOpaqueObject } },
+          }),
+          "503": errorResponse("Codex control plane is unavailable"),
+        },
+      },
+    },
+    "/api/v1/codex/requests/user-input/{request_id}/respond": {
+      post: {
+        tags: ["Codex"],
+        summary: "Respond to a pending Codex user-input request",
+        operationId: "respondToCodexUserInputRequest",
+        parameters: [pathParam("request_id", "Pending request identifier")],
+        requestBody: {
+          required: true,
+          content: jsonContent({
+            type: "object",
+            properties: { result: {} },
+          }),
+        },
+        responses: {
+          "200": jsonResponse("Response accepted", {
+            type: "object",
+            properties: { ok: { type: "boolean" } },
+          }),
+          "404": errorResponse("Pending request not found"),
+          "503": errorResponse("Codex control plane is unavailable"),
+        },
+      },
+    },
+  };
+}

--- a/src/http/openapi.ts
+++ b/src/http/openapi.ts
@@ -5,9 +5,11 @@
  * Uses Zod 4's built-in `z.toJSONSchema()` — no external OpenAPI library needed.
  */
 
+import packageJson from "../../package.json" with { type: "json" };
 import {
   buildAlertPaths,
   buildAutomationPaths,
+  buildCodexPaths,
   buildIngressPaths,
   buildInfrastructurePaths,
   buildIssuePaths,
@@ -25,7 +27,7 @@ export function getOpenApiSpec(): Record<string, unknown> {
     openapi: "3.1.0",
     info: {
       title: "Risoluto API",
-      version: "0.4.0",
+      version: packageJson.version,
       description: "REST API for Risoluto — manages issues, workspaces, config, and agent lifecycle.",
     },
     servers: [{ url: "http://localhost:4000", description: "Local Risoluto instance" }],
@@ -52,6 +54,7 @@ export function getOpenApiSpec(): Record<string, unknown> {
       ...buildIngressPaths(),
       ...buildPrPaths(),
       ...buildInfrastructurePaths(),
+      ...buildCodexPaths(),
     },
   };
   return cachedSpec;


### PR DESCRIPTION
## Summary

Brings the Mintlify docs site in sync with the v1 architecture rewrite, the agent-readiness refactor, and post-v0.6.0 HTTP route additions, plus a handful of Mintlify upgrades while the docs were already open.

**Codebase sync**
- `src/http/openapi.ts` — spec version now reads from `package.json` (was hardcoded `"0.4.0"`) and wires a new `buildCodexPaths()` into the generator
- `src/http/openapi-paths.ts` — new `buildCodexPaths()` covering 21 `/api/v1/codex/*` routes that shipped without OpenAPI coverage. Closes a latent violation of `.claude/rules/modification-patterns.md` step 4 ("update the OpenAPI spec when adding an endpoint")
- `docs-site/openapi.json` — regenerated from the live endpoint. `info.version` 0.4.0 → 0.6.0, 35 → 56 paths

**Content sync**
- `api-reference/endpoints.mdx` — new Notifications, Automations, Alerts, and **Codex Operator** sections; documents GitHub webhook, `/api/v1/webhooks/trigger`, checkpoints, observability, recovery
- `guides/configuration.mdx` — adds `notifications.channels[]` (slack / webhook / desktop shapes), `mergePolicy`, `stateMachine`, `repos[]` multi-repo routing, and the `RISOLUTO_READ_TOKEN` env var
- `operating/observability.mdx` — webhook metrics accordion (10 families) plus container CPU/memory gauges
- `guides/dashboard.mdx` — Containers, Observability, Notifications cards for the v1 God-View split
- `quickstart.mdx` — `--data-dir` flag, normalized `localhost:4000` on the Docker path
- `changelog.mdx` — Unreleased entry for `2aa37fa`, `4167da1`, `1dd2461`

**Mintlify upgrades**
- `docs.json` — footer link columns (Docs + Resources), Symphony→Risoluto redirects safety net, removed 5 dead MCP contextual buttons (`mcp`, `add-mcp`, `cursor`, `vscode`, `devin-mcp` — all required an `mcp` server block that was never configured), pre-launch beta banner
- `introduction.mdx` — pre-launch beta `<Note>` callout + language tag on a bare code fence
- `operating/troubleshooting.mdx` — Master Key reset variants wrapped in a `<CodeGroup>`
- `images/README.md` (new) + `.mintignore` entry — flags the missing `og-image.png` binary that `seo.metatags` references but was never committed

**Known follow-ups (intentionally out of scope)**
- The actual `og-image.png` binary (1200×630) still needs to be produced and committed
- 17+ `/api/v1/setup/*` wizard endpoints remain undocumented (wizard internals — deserves its own batch)

## Test plan

- [x] `jq .` validates `docs-site/docs.json` and `docs-site/openapi.json`
- [x] `mint validate` from `docs-site/` — build validation passed, OpenAPI definition valid
- [x] `mint broken-links` from `docs-site/` — no broken links
- [x] `pnpm run build` — compiles cleanly including the new Codex path builder
- [x] `pnpm run lint` — 0 errors (1 pre-existing warning in `tests/git/manager.test.ts`)
- [x] `pnpm run format:check` — clean
- [x] `pnpm test` — 273 files / 3767 tests passing, 1 skipped
- [x] Pre-push hook (build + test + typecheck, both `tsconfig.json` and `frontend/tsconfig.json`) — passed
- [ ] Spot-check the rendered docs-site in a Mintlify preview deploy (reviewer)
- [ ] Confirm the `og-image.png` follow-up lands before the public launch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/omerfarukoruc/risoluto/pull/397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the docs site with v0.6.0 and the v1 architecture. Adds OpenAPI coverage for Codex routes, auto-versions the spec from `package.json`, and updates docs for new endpoints, config, observability, and dashboard pages with Mintlify UX upgrades.

- **New Features**
  - OpenAPI: version now reads from `package.json`; added 21 `/api/v1/codex/*` routes; regenerated spec (35 → 56 paths).
  - Docs: new sections for Notifications, Automations, Alerts, and Codex Operator; added observability and recovery endpoints; GitHub webhook and manual trigger docs; config updates for `notifications.channels[]`, `mergePolicy`, `stateMachine`, multi-repo `repos[]`, and `RISOLUTO_READ_TOKEN`.
  - Observability & UI: container CPU/memory gauges and webhook metrics; new Containers, Observability, and Notifications dashboard pages; Quickstart normalized to `localhost:4000`; changelog updated; `images/README.md` added for missing `og-image.png`.

- **Dependencies**
  - Mintlify: pre-launch beta banner, footer link columns, Symphony→Risoluto redirects; removed unused contextual buttons (`mcp`, `add-mcp`, `cursor`, `vscode`, `devin-mcp`); intro beta note and troubleshooting CodeGroup.

<sup>Written for commit 36d16b2738957c74e85cac016c2604bdb91ef218. Summary will update on new commits. <a href="https://cubic.dev/pr/OmerFarukOruc/risoluto/pull/397">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

